### PR TITLE
Add SEO metadata to topic pages and topic routes to sitemap

### DIFF
--- a/app/[locale]/(public)/topics/[slug]/page.tsx
+++ b/app/[locale]/(public)/topics/[slug]/page.tsx
@@ -1,3 +1,4 @@
+import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 import { getTranslations } from "next-intl/server";
 import NanoTemplateDetailClient from "@/app/[locale]/(public)/nano-template/[slug]/NanoTemplateDetailClient";
@@ -17,6 +18,7 @@ import {
   makeSafeTranslator,
   titleCaseFromSlug,
 } from "@/lib/locale_utils";
+import { getCanonicalUrl, getLanguagesMap } from "@/lib/canonical";
 
 import { getTemplatesForTopic, getRelatedTopics, getParentTopic, getChildTopics, getTopicById } from "@/lib/topicRegistry";
 
@@ -27,6 +29,31 @@ export const dynamic = "force-dynamic";
 type Props = {
   params: Promise<{ locale: string; slug: string }>;
 };
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const { locale, slug } = await params;
+
+  const t = await getTranslations({ locale });
+  const safeT = (key: string) => { try { return t(key as never) ?? ""; } catch { return ""; } };
+
+  const displayName = safeT(`topics.${slug}.displayName`) || titleCaseFromSlug(slug);
+  const title = safeT(`topics.${slug}.title`) || `${displayName} — Nano Banana AI Templates`;
+  const description = safeT(`topics.${slug}.description`) || `Explore ${displayName} AI visual templates and prompts on Nano Banana.`;
+
+  const canonical = getCanonicalUrl(locale, `/topics/${slug}`);
+  const languages = getLanguagesMap(`/topics/${slug}`);
+
+  return {
+    title,
+    description,
+    alternates: { canonical, languages },
+    openGraph: {
+      title: `${displayName} | Nano Banana`,
+      description,
+      url: canonical,
+    },
+  };
+}
 
 export default async function Page({ params }: Props) {
   const { locale: localeStr, slug } = await params;

--- a/app/sitemap.xml/route.ts
+++ b/app/sitemap.xml/route.ts
@@ -56,6 +56,23 @@ function getUseCaseRoutes(): string[] {
   return USE_CASES.map((uc) => `/use-cases/${uc.slug}`);
 }
 
+function getTopicRoutes(): string[] {
+  // Collect topics that appear directly on templates (parent-level topics)
+  const templateLevelTopics = new Set<string>();
+  for (const t of nanoTemplates as unknown as Array<{ topics?: string | string[] }>) {
+    const raw = t.topics;
+    const topics = Array.isArray(raw)
+      ? raw
+      : typeof raw === "string"
+      ? raw.split(",").map((s) => s.trim())
+      : [];
+    for (const tp of topics) {
+      if (tp) templateLevelTopics.add(tp.toLowerCase());
+    }
+  }
+  return Array.from(templateLevelTopics).map((tp) => `/topics/${tp}`);
+}
+
 function generateHreflangLinks(
   route: string,
   availableLocales?: readonly string[]
@@ -110,6 +127,7 @@ export async function GET() {
   const toolRoutes = getToolRoutes();
   const tagRoutes = getTagRoutes();
   const useCaseRoutes = getUseCaseRoutes();
+  const topicRoutes = getTopicRoutes();
 
   let urls = "";
 
@@ -120,6 +138,17 @@ export async function GET() {
         lastmod: STABLE_LASTMOD,
         changefreq: route === "" ? "daily" : "weekly",
         priority: route === "" && locale === "en" ? "1.0" : "0.8",
+      });
+    });
+  });
+
+  // Topic pages
+  topicRoutes.forEach((route) => {
+    LOCALES.forEach((locale) => {
+      urls += generateUrlEntry(locale, route, {
+        lastmod: STABLE_LASTMOD,
+        changefreq: "weekly",
+        priority: "0.8",
       });
     });
   });


### PR DESCRIPTION
- generateMetadata on topics/[slug]/page.tsx using title/description from home.json
- Adds canonical URL and hreflang alternates
- getTopicRoutes() in sitemap.xml/route.ts adds all parent-level topics at priority 0.8