### PR TITLE
Show language/character subtopics in nav at top of parent topic pages

### DIFF
--- a/app/[locale]/(public)/topics/[slug]/page.tsx
+++ b/app/[locale]/(public)/topics/[slug]/page.tsx
@@ -170,6 +170,18 @@ export default async function Page({ params }: Props) {
               />
             </div>
           )}
+
+          {!isChildTopic && visibleSubTopics.length > 0 && (
+            <div className="mt-4">
+              <TopicNavRow
+                locale={localeStr}
+                topics={visibleSubTopics}
+                activeTopic={slug}
+                showDisabled={false}
+                size="small"
+              />
+            </div>
+          )}
         </div>
       </section>
 

--- a/lib/topicRegistry.ts
+++ b/lib/topicRegistry.ts
@@ -66,6 +66,13 @@ const EXPLICIT_SIBLING_GROUPS: string[][] = [
   ["english-chinese", "english-spanish", "english-korean", "english-japanese"],
 ];
 
+// Explicit parent→children for top-level topics that are semantically subtopics
+// but appear directly on templates (so co-occurrence detection won't catch them).
+const EXPLICIT_CHILD_TOPICS: Record<string, string[]> = {
+  language: ["vocabulary", "dialogue", "expressions", "language-english"],
+  character: ["comparison", "groups"],
+};
+
 // A single co-occurrence row: topics that appear together for a given template
 type TopicRow = {
   templateId: string;
@@ -245,7 +252,9 @@ export function getRelatedTopics(topicId: string): string[] {
 }
 
 export function getChildTopics(topicId: string): string[] {
-  return registry.childTopics.get(topicId) ?? [];
+  const auto = registry.childTopics.get(topicId) ?? [];
+  const explicit = EXPLICIT_CHILD_TOPICS[topicId] ?? [];
+  return [...new Set([...explicit, ...auto])];
 }
 
 export function getParentTopic(topicId: string): string | undefined {


### PR DESCRIPTION
- Add EXPLICIT_CHILD_TOPICS for language (vocabulary, dialogue, expressions, language-english) and character (comparison, groups)
- Merge explicit children into getChildTopics()
- Render subtopics nav row at top of parent pages