### PR TITLE
Fix locales on language pair inspiration entries

### DIFF
--- a/public/data/nano_inspiration.json
+++ b/public/data/nano_inspiration.json
@@ -24886,7 +24886,10 @@
       "topic_name": "Animal Actions English Spanish"
     },
     "locales": {
-      "zh": {
+      "en": {
+        "title": "animal actions english spanish"
+      },
+      "es": {
         "title": "animal actions english spanish"
       }
     },
@@ -24912,7 +24915,10 @@
       "topic_name": "Desserts English Korean"
     },
     "locales": {
-      "zh": {
+      "en": {
+        "title": "desserts english korean"
+      },
+      "ko": {
         "title": "desserts english korean"
       }
     },
@@ -24938,7 +24944,10 @@
       "topic_name": "Desserts English Spanish"
     },
     "locales": {
-      "zh": {
+      "en": {
+        "title": "desserts english spanish"
+      },
+      "es": {
         "title": "desserts english spanish"
       }
     },
@@ -25680,6 +25689,9 @@
     "locales": {
       "en": {
         "title": "Colors"
+      },
+      "es": {
+        "title": "Colors"
       }
     },
     "topics": [
@@ -25705,6 +25717,9 @@
     },
     "locales": {
       "en": {
+        "title": "Family Members"
+      },
+      "es": {
         "title": "Family Members"
       }
     },
@@ -25733,6 +25748,9 @@
     "locales": {
       "en": {
         "title": "Food & Drink"
+      },
+      "es": {
+        "title": "Food & Drink"
       }
     },
     "topics": [
@@ -25757,6 +25775,9 @@
     },
     "locales": {
       "en": {
+        "title": "La Maestra (The Teacher)"
+      },
+      "es": {
         "title": "La Maestra (The Teacher)"
       }
     },
@@ -25783,6 +25804,9 @@
     },
     "locales": {
       "en": {
+        "title": "El Cocinero (The Chef)"
+      },
+      "es": {
         "title": "El Cocinero (The Chef)"
       }
     },
@@ -25811,6 +25835,9 @@
     "locales": {
       "en": {
         "title": "La Deportista (The Athlete)"
+      },
+      "es": {
+        "title": "La Deportista (The Athlete)"
       }
     },
     "topics": [
@@ -25835,6 +25862,9 @@
     },
     "locales": {
       "en": {
+        "title": "El Bombero (The Firefighter)"
+      },
+      "es": {
         "title": "El Bombero (The Firefighter)"
       }
     },
@@ -25861,6 +25891,9 @@
     },
     "locales": {
       "en": {
+        "title": "Ordering Food"
+      },
+      "es": {
         "title": "Ordering Food"
       }
     },
@@ -25889,6 +25922,9 @@
     "locales": {
       "en": {
         "title": "Asking for Directions"
+      },
+      "es": {
+        "title": "Asking for Directions"
       }
     },
     "topics": [
@@ -25914,6 +25950,9 @@
     },
     "locales": {
       "en": {
+        "title": "Shopping for Clothes"
+      },
+      "es": {
         "title": "Shopping for Clothes"
       }
     },
@@ -25941,6 +25980,9 @@
     "locales": {
       "en": {
         "title": "Colors"
+      },
+      "ko": {
+        "title": "Colors"
       }
     },
     "topics": [
@@ -25965,6 +26007,9 @@
     },
     "locales": {
       "en": {
+        "title": "Family Members"
+      },
+      "ko": {
         "title": "Family Members"
       }
     },
@@ -25993,6 +26038,9 @@
     "locales": {
       "en": {
         "title": "Daily Objects"
+      },
+      "ko": {
+        "title": "Daily Objects"
       }
     },
     "topics": [
@@ -26017,6 +26065,9 @@
     },
     "locales": {
       "en": {
+        "title": "Busy Student (바쁜 학생)"
+      },
+      "ko": {
         "title": "Busy Student (바쁜 학생)"
       }
     },
@@ -26044,6 +26095,9 @@
     "locales": {
       "en": {
         "title": "K-Pop Fan Tourist (케이팝 팬 관광객)"
+      },
+      "ko": {
+        "title": "K-Pop Fan Tourist (케이팝 팬 관광객)"
       }
     },
     "topics": [
@@ -26066,6 +26120,9 @@
     },
     "locales": {
       "en": {
+        "title": "Little Dragon (아기 용)"
+      },
+      "ko": {
         "title": "Little Dragon (아기 용)"
       }
     },
@@ -26092,6 +26149,9 @@
     "locales": {
       "en": {
         "title": "Robot Chef (로봇 요리사)"
+      },
+      "ko": {
+        "title": "Robot Chef (로봇 요리사)"
       }
     },
     "topics": [
@@ -26114,6 +26174,9 @@
     },
     "locales": {
       "en": {
+        "title": "Ordering Coffee"
+      },
+      "ko": {
         "title": "Ordering Coffee"
       }
     },
@@ -26141,6 +26204,9 @@
     "locales": {
       "en": {
         "title": "Asking for Directions"
+      },
+      "ko": {
+        "title": "Asking for Directions"
       }
     },
     "topics": [
@@ -26165,6 +26231,9 @@
     },
     "locales": {
       "en": {
+        "title": "Making Plans with a Friend"
+      },
+      "ko": {
         "title": "Making Plans with a Friend"
       }
     },
@@ -26191,6 +26260,9 @@
     },
     "locales": {
       "en": {
+        "title": "Fruits"
+      },
+      "ja": {
         "title": "Fruits"
       }
     },
@@ -26219,6 +26291,9 @@
     "locales": {
       "en": {
         "title": "Stationery"
+      },
+      "ja": {
+        "title": "Stationery"
       }
     },
     "topics": [
@@ -26244,6 +26319,9 @@
     },
     "locales": {
       "en": {
+        "title": "Family Members"
+      },
+      "ja": {
         "title": "Family Members"
       }
     },
@@ -26272,6 +26350,9 @@
     "locales": {
       "en": {
         "title": "Daily Greetings"
+      },
+      "ja": {
+        "title": "Daily Greetings"
       }
     },
     "topics": [
@@ -26298,6 +26379,9 @@
     "locales": {
       "en": {
         "title": "お母さん (Mother)"
+      },
+      "ja": {
+        "title": "お母さん (Mother)"
       }
     },
     "topics": [
@@ -26323,6 +26407,9 @@
     "locales": {
       "en": {
         "title": "外国人旅行者 (Foreign Tourist)"
+      },
+      "ja": {
+        "title": "外国人旅行者 (Foreign Tourist)"
       }
     },
     "topics": [
@@ -26347,6 +26434,9 @@
     },
     "locales": {
       "en": {
+        "title": "寿司職人 (Sushi Chef)"
+      },
+      "ja": {
         "title": "寿司職人 (Sushi Chef)"
       }
     },
@@ -26374,6 +26464,9 @@
     "locales": {
       "en": {
         "title": "祭り参加者 (Festival Participant)"
+      },
+      "ja": {
+        "title": "祭り参加者 (Festival Participant)"
       }
     },
     "topics": [
@@ -26400,6 +26493,9 @@
     "locales": {
       "en": {
         "title": "Ordering Coffee"
+      },
+      "ja": {
+        "title": "Ordering Coffee"
       }
     },
     "topics": [
@@ -26424,6 +26520,9 @@
     },
     "locales": {
       "en": {
+        "title": "Asking for Directions"
+      },
+      "ja": {
         "title": "Asking for Directions"
       }
     },


### PR DESCRIPTION
english-spanish entries now have en+es, english-korean en+ko, english-japanese en+ja instead of incorrect zh locale.