### PR TITLE
Add remix link to ExampleImageCard in example grids

### DIFF
--- a/app/[locale]/(public)/nano-template/[slug]/ExampleImagesGrid.tsx
+++ b/app/[locale]/(public)/nano-template/[slug]/ExampleImagesGrid.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from "react";
 import Link from "next/link";
+import { Sparkles } from "lucide-react";
 import CdnImage from "@/app/[locale]/_components/CdnImage";
 import { toSlug } from "@/lib/nano_utils";
 import { useClickTracking } from "@/services/useTracking";
@@ -11,6 +12,7 @@ type Item = {
   title: string;
   preview: string;
   templateId: string;
+  params?: Record<string, string>;
 };
 
 function getCols() {
@@ -45,13 +47,20 @@ function ExampleImageCard({
 }) {
   const trackClick = useClickTracking(`${item.templateId}:${item.id}`, "nano_inspiration", "cards");
 
+  const remixHref = (() => {
+    const qs = item.params && Object.keys(item.params).length > 0
+      ? `?${new URLSearchParams(item.params).toString()}`
+      : "";
+    return `/${locale}/nano-template/${toSlug(item.templateId)}${qs}#reproduce`;
+  })();
+
   return (
-    <Link
-      href={`/${locale}/nano-template/${toSlug(item.templateId)}/example/${encodeURIComponent(item.id)}`}
-      onClick={trackClick}
-      className="group block overflow-hidden rounded-3xl border border-neutral-200 bg-white shadow-sm transition-all duration-200 hover:-translate-y-0.5 hover:shadow-md"
-    >
-      <div className="relative overflow-hidden">
+    <div className="group overflow-hidden rounded-3xl border border-neutral-200 bg-white shadow-sm transition-all duration-200 hover:-translate-y-0.5 hover:shadow-md">
+      <Link
+        href={`/${locale}/nano-template/${toSlug(item.templateId)}/example/${encodeURIComponent(item.id)}`}
+        onClick={trackClick}
+        className="block relative overflow-hidden"
+      >
         <CdnImage
           src={item.preview}
           alt={item.title || item.id}
@@ -63,8 +72,18 @@ function ExampleImageCard({
             View prompt →
           </span>
         </div>
+      </Link>
+
+      <div className="px-3 py-2">
+        <Link
+          href={remixHref}
+          className="flex items-center gap-1.5 text-xs font-semibold text-purple-600 hover:text-purple-800"
+        >
+          <Sparkles className="h-3.5 w-3.5" />
+          Remix this
+        </Link>
       </div>
-    </Link>
+    </div>
   );
 }
 

--- a/lib/nano_page_data.ts
+++ b/lib/nano_page_data.ts
@@ -91,6 +91,7 @@ export function buildTemplateImageGridItems(
       title: img.title || "",
       preview: img.preview_image_url || img.image_url,
       templateId: img.template_id,
+      params: img.params ?? {},
     }));
 }
 
@@ -105,6 +106,7 @@ export function buildSimilarExampleGridItems(
     title: (img.locales?.["en"]?.title ?? img.locales?.["zh"]?.title ?? ""),
     preview: img.asset.preview_image_url || img.asset.image_url,
     templateId: img.template_id,
+    params: img.params ?? {},
   }));
 }
 
@@ -123,6 +125,7 @@ export function buildOrderedTemplateImageGridItems(
       title: img.title || "",
       preview: img.preview_image_url || img.image_url,
       templateId: img.template_id,
+      params: img.params ?? {},
     }));
 }
 


### PR DESCRIPTION
Each card now shows a Remix this link below the image that pre-fills the template parameters and jumps to the reproduce section, matching the remix button on the example detail page.

- Pass params through all three grid item builders in nano_page_data.ts
- ExampleImagesGrid Item type gains optional params field
- Card splits into image link and remix link in a bottom strip