### PR TITLE
Fix sync_nanoprompts_to_redis to handle flat array format

### DIFF
--- a/scripts/sync_nanoprompts_to_redis.cjs
+++ b/scripts/sync_nanoprompts_to_redis.cjs
@@ -71,7 +71,8 @@ async function main() {
   const raw = fs.readFileSync(SOURCE_PATH, "utf-8");
   const parsed = JSON.parse(raw);
 
-  const prompts = Array.isArray(parsed.prompts) ? parsed.prompts : [];
+  // Support both flat array and { prompts: [...] } wrapper formats
+  const prompts = Array.isArray(parsed) ? parsed : (Array.isArray(parsed.prompts) ? parsed.prompts : []);
   const validPrompts = prompts.filter(validatePrompt);
 
   console.log(`Loaded ${prompts.length} prompts, ${validPrompts.length} valid.`);


### PR DESCRIPTION
nanobanana.json is a flat array but the script expected { prompts: [...] }, causing most_popular to be written as [] and the gallery page to show nothing.