### PR TITLE
Tag portrait and monochrome on first templates to enable topic pages

### DIFF
--- a/public/data/nano_templates.json
+++ b/public/data/nano_templates.json
@@ -1390,7 +1390,8 @@
       "character",
       "gaming",
       "comparison",
-      "ink"
+      "ink",
+      "monochrome"
     ],
     "rank_score": 80,
     "use_cases": [
@@ -4206,7 +4207,8 @@
     "og_image": "/images/nano_insp_preview/template-cartoon-character-profile-card-kawaii-style-adventurer-max-prev.jpg",
     "topics": [
       "character",
-      "kawaii"
+      "kawaii",
+      "portrait"
     ],
     "rank_score": 70
   },


### PR DESCRIPTION
portrait → template-cartoon-character-profile-card-kawaii-style monochrome → template-battle (already ink-tagged)