### PR TITLE
Replace /user/saved-items API call with interaction tracking for save

### DIFF
--- a/app/[locale]/(public)/nano-template/[slug]/ExampleImagesGrid.tsx
+++ b/app/[locale]/(public)/nano-template/[slug]/ExampleImagesGrid.tsx
@@ -9,7 +9,6 @@ import CdnImage from "@/app/[locale]/_components/CdnImage";
 import { toSlug } from "@/lib/nano_utils";
 import { useClickTracking, useTracking } from "@/services/useTracking";
 import { templatePacksService } from "@/services/templatePacks";
-import { savedItemsService } from "@/services/savedItemsService";
 import { userAtom, drawerAtom } from "@/app/atoms/atoms";
 
 type Item = {
@@ -61,19 +60,14 @@ function ExampleImageCard({
   const [saved, setSaved] = useState(false);
   const [showSavedToast, setShowSavedToast] = useState(false);
 
-  const handleSave = async (e: React.MouseEvent) => {
+  const handleSave = (e: React.MouseEvent) => {
     e.preventDefault();
     if (saved) return;
     if (!user) { setDrawerState("signin"); return; }
     setSaved(true);
-    try {
-      await savedItemsService.save(item.id, "nano_inspiration");
-      trackAction(tracking, "favorite");
-      setShowSavedToast(true);
-      setTimeout(() => setShowSavedToast(false), 3000);
-    } catch {
-      setSaved(false);
-    }
+    trackAction(tracking, "favorite");
+    setShowSavedToast(true);
+    setTimeout(() => setShowSavedToast(false), 3000);
   };
 
   const tracking = {

--- a/app/[locale]/_components/NanoInspirationCard.tsx
+++ b/app/[locale]/_components/NanoInspirationCard.tsx
@@ -14,7 +14,6 @@ import {
   useTracking,
 } from "@/services/useTracking";
 import { templatePacksService } from "@/services/templatePacks";
-import { savedItemsService } from "@/services/savedItemsService";
 import { userAtom, drawerAtom } from "@/app/atoms/atoms";
 import {
   makeNanoTemplateUrl,
@@ -60,19 +59,14 @@ export function NanoInspirationCard({
   const [saved, setSaved] = useState(false);
   const [showSavedToast, setShowSavedToast] = useState(false);
 
-  const handleSave = async (e: React.MouseEvent) => {
+  const handleSave = (e: React.MouseEvent) => {
     e.stopPropagation();
     if (saved) return;
     if (!user) { setDrawerState("signin"); return; }
     setSaved(true);
-    try {
-      await savedItemsService.save(card.id, "nano_inspiration");
-      trackAction(batchTracking, "favorite");
-      setShowSavedToast(true);
-      setTimeout(() => setShowSavedToast(false), 3000);
-    } catch {
-      setSaved(false);
-    }
+    trackAction(batchTracking, "favorite");
+    setShowSavedToast(true);
+    setTimeout(() => setShowSavedToast(false), 3000);
   };
 
   const batchTracking = {

--- a/app/[locale]/_components/UnifiedActionBar.tsx
+++ b/app/[locale]/_components/UnifiedActionBar.tsx
@@ -12,7 +12,6 @@ import CopyPromptButton from "@/app/[locale]/_components/CopyPromptButton";
 import ShareButton from "@/app/[locale]/_components/ShareButton";
 import { useTracking, useSaveTracking, type TrackingTarget } from "@/services/useTracking";
 import { templatePacksService } from "@/services/templatePacks";
-import { savedItemsService } from "@/services/savedItemsService";
 import { userAtom, drawerAtom, clientMountedAtom } from "@/app/atoms/atoms";
 
 type GenerateConfig = {
@@ -101,7 +100,7 @@ export default function UnifiedActionBar({
   const [isBatchDownloading, setIsBatchDownloading] = useState(false);
   const [saved, setSaved] = useState(false);
 
-  const handleSave = async () => {
+  const handleSave = () => {
     if (!save || saved) return;
     if (!user) {
       setDrawerState("signin");
@@ -109,11 +108,6 @@ export default function UnifiedActionBar({
     }
     setSaved(true);
     trackSave();
-    try {
-      await savedItemsService.save(tracking.contentId, tracking.contentType);
-    } catch {
-      setSaved(false);
-    }
   };
 
   const handleGenerate = async () => {


### PR DESCRIPTION
The backend has no /user/saved-items endpoint. Saving is now handled entirely via trackAction("favorite") to /interactions/track, which records the event in the interactions table. User profile picks up saved_content_ids from there. Removed savedItemsService import and async/try-catch wrappers from all three save handlers.