### PR TITLE
Remove overlap-based related topics logic from topicRegistry

### DIFF
--- a/lib/nano_example_utils.ts
+++ b/lib/nano_example_utils.ts
@@ -60,6 +60,7 @@ export function getImageViewsForTemplate(
   locale: PageLocale
 ): ImageView[] {
   const imgs = reg.imagesByTemplateId.get(templateId) ?? [];
+  const rankScore = reg.templates.find((t) => t.id === templateId)?.rank_score;
 
   return imgs.map((img) => {
     const loc =
@@ -77,6 +78,7 @@ export function getImageViewsForTemplate(
       params: img.params ?? {},
       image_url: imageUrl,
       preview_image_url: previewUrl,
+      rank_score: rankScore,
     };
   });
 }

--- a/lib/nano_page_data.ts
+++ b/lib/nano_page_data.ts
@@ -114,19 +114,43 @@ export function buildOrderedTemplateImageGridItems(
   imageViews: NanoImageView[],
   orderedImageIds?: string[]
 ) {
-  const imageMap = new Map(imageViews.map((x) => [x.id, x] as const));
-  const ids = orderedImageIds?.length ? orderedImageIds : imageViews.map((x) => x.id);
+  const toItem = (img: NanoImageView) => ({
+    id: img.id,
+    title: img.title || "",
+    preview: img.preview_image_url || img.image_url,
+    templateId: img.template_id,
+    params: img.params ?? {},
+  });
 
-  return ids
-    .map((id) => imageMap.get(id))
-    .filter((img): img is NanoImageView => Boolean(img))
-    .map((img) => ({
-      id: img.id,
-      title: img.title || "",
-      preview: img.preview_image_url || img.image_url,
-      templateId: img.template_id,
-      params: img.params ?? {},
-    }));
+  if (orderedImageIds?.length) {
+    const imageMap = new Map(imageViews.map((x) => [x.id, x] as const));
+    return orderedImageIds
+      .map((id) => imageMap.get(id))
+      .filter((img): img is NanoImageView => Boolean(img))
+      .map(toItem);
+  }
+
+  // Group by template, sort groups by rank_score desc, then interleave round-robin
+  const groups = new Map<string, NanoImageView[]>();
+  for (const img of imageViews) {
+    const arr = groups.get(img.template_id) ?? [];
+    arr.push(img);
+    groups.set(img.template_id, arr);
+  }
+
+  const sortedGroups = Array.from(groups.values()).sort(
+    (a, b) => (b[0].rank_score ?? 1) - (a[0].rank_score ?? 1)
+  );
+
+  const result: NanoImageView[] = [];
+  const maxLen = Math.max(0, ...sortedGroups.map((g) => g.length));
+  for (let i = 0; i < maxLen; i++) {
+    for (const group of sortedGroups) {
+      if (i < group.length) result.push(group[i]);
+    }
+  }
+
+  return result.map(toItem);
 }
 
 export function buildNanoFeedCards(

--- a/lib/nano_utils.ts
+++ b/lib/nano_utils.ts
@@ -71,6 +71,7 @@ export type ImageView = {
   params: Record<string, any>;
   image_url: string;
   preview_image_url?: string;
+  rank_score?: number;
 };
 
 export type NanoInspirationCardType = {

--- a/lib/topicRegistry.ts
+++ b/lib/topicRegistry.ts
@@ -175,27 +175,7 @@ function buildTopicRegistry(): TopicRegistry {
     enrichedTopics.map((t) => [t.id, t])
   );
 
-  // Related topics: only among true Tier 1 topics (entry bar)
-  const TIER1_TOPICS = new Set(["character", "language", "travel", "lifestyle", "learning", "product", "design"]);
-  const RELATED_FOCUS = new Set(["learning", "character", "travel", "lifestyle", "product"]);
-  const MIN_OVERLAP = 2;
-  const relatedTopics = new Map<string, string[]>();
-  const tier1Ids = allTopicIds.filter((id) => TIER1_TOPICS.has(id));
-
-  for (const a of tier1Ids) {
-    if (!RELATED_FOCUS.has(a)) continue;
-    const aIds = topicToTemplateIds.get(a)!;
-    const related: string[] = [];
-    for (const b of tier1Ids) {
-      if (a === b) continue;
-      const bIds = topicToTemplateIds.get(b)!;
-      const overlap = [...aIds].filter((id) => bIds.has(id)).length;
-      if (overlap >= MIN_OVERLAP) related.push(b);
-    }
-    if (related.length > 0) relatedTopics.set(a, related);
-  }
-
-  return { topics: enrichedTopics, topicById, topicToTemplates, templateToTopics, relatedTopics };
+  return { topics: enrichedTopics, topicById, topicToTemplates, templateToTopics, relatedTopics: new Map() };
 }
 
 const registry = buildTopicRegistry();


### PR DESCRIPTION
Dynamic related topics were computed by counting shared templates between tier 1 topics, causing unrelated topics (e.g. design) to appear on lifestyle's topic page. Replaced with an empty map so related topics are never surfaced implicitly.