### PR TITLE
Clean urban/cinematic/futuristic gallery tags and map to city/film/ai…

### DIFF
--- a/lib/topicRegistry.ts
+++ b/lib/topicRegistry.ts
@@ -102,6 +102,9 @@ const TOPIC_GALLERY_TAG: Record<string, string> = {
   monochrome:     "monochrome",
   watercolor:     "watercolor",
   animal:         "animal",
+  city:           "urban",
+  film:           "cinematic",
+  ai:             "futuristic",
 };
 
 // Blog tag to pull posts for a topic page.


### PR DESCRIPTION
… topics

- urban: 184 → 40 items (city/landmark content only)
- cinematic: 338 → 21 items (pop culture IPs only)
- futuristic: 71 → 14 items (AI/tech content only)
- Map city→urban, film→cinematic, ai→futuristic in TOPIC_GALLERY_TAG