### PR TITLE
Add smooth swipe lightbox to ExampleImagesGrid

### DIFF
--- a/app/[locale]/(public)/nano-template/[slug]/ExampleImagesGrid.tsx
+++ b/app/[locale]/(public)/nano-template/[slug]/ExampleImagesGrid.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useRef, useState, useCallback } from "react";
 import Link from "next/link";
-import { Bookmark, Download, Sparkles } from "lucide-react";
+import { Bookmark, Download, Sparkles, X, ChevronLeft, ChevronRight } from "lucide-react";
 import { useAtom } from "jotai";
 import { useTranslations } from "next-intl";
 import CdnImage from "@/app/[locale]/_components/CdnImage";
@@ -43,12 +43,216 @@ function useCols() {
   return cols;
 }
 
+// ── Lightbox ────────────────────────────────────────────────────────────────
+
+function Lightbox({
+  items,
+  initialIndex,
+  locale,
+  onClose,
+}: {
+  items: Item[];
+  initialIndex: number;
+  locale: string;
+  onClose: () => void;
+}) {
+  const [index, setIndex] = useState(initialIndex);
+  const [dragX, setDragX] = useState(0);
+  const [isDragging, setIsDragging] = useState(false);
+  const touchStartX = useRef(0);
+  const touchStartY = useRef(0);
+  const dragStartX = useRef(0);
+  const isHorizontalSwipe = useRef<boolean | null>(null);
+  const trackRef = useRef<HTMLDivElement>(null);
+
+  // Lock body scroll
+  useEffect(() => {
+    const prev = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+    return () => { document.body.style.overflow = prev; };
+  }, []);
+
+  // Keyboard navigation
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+      if (e.key === "ArrowRight") goTo(index + 1);
+      if (e.key === "ArrowLeft") goTo(index - 1);
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  });
+
+  const goTo = useCallback((next: number) => {
+    setIndex(Math.max(0, Math.min(items.length - 1, next)));
+    setDragX(0);
+  }, [items.length]);
+
+  // Touch handlers
+  const onTouchStart = (e: React.TouchEvent) => {
+    touchStartX.current = e.touches[0].clientX;
+    touchStartY.current = e.touches[0].clientY;
+    dragStartX.current = e.touches[0].clientX;
+    isHorizontalSwipe.current = null;
+    setIsDragging(true);
+  };
+
+  const onTouchMove = (e: React.TouchEvent) => {
+    const dx = e.touches[0].clientX - touchStartX.current;
+    const dy = e.touches[0].clientY - touchStartY.current;
+
+    // Determine swipe direction on first meaningful move
+    if (isHorizontalSwipe.current === null && (Math.abs(dx) > 4 || Math.abs(dy) > 4)) {
+      isHorizontalSwipe.current = Math.abs(dx) > Math.abs(dy);
+    }
+
+    if (!isHorizontalSwipe.current) return;
+
+    e.preventDefault();
+
+    const raw = e.touches[0].clientX - dragStartX.current;
+    // Rubber-band at edges
+    const atStart = index === 0 && raw > 0;
+    const atEnd = index === items.length - 1 && raw < 0;
+    setDragX(atStart || atEnd ? raw * 0.15 : raw);
+  };
+
+  const onTouchEnd = () => {
+    setIsDragging(false);
+    if (!isHorizontalSwipe.current) { setDragX(0); return; }
+
+    const threshold = window.innerWidth * 0.25;
+    if (dragX < -threshold && index < items.length - 1) {
+      goTo(index + 1);
+    } else if (dragX > threshold && index > 0) {
+      goTo(index - 1);
+    } else {
+      setDragX(0);
+    }
+  };
+
+  const item = items[index];
+  const exampleHref = `/${locale}/nano-template/${toSlug(item.templateId)}/example/${encodeURIComponent(item.id)}`;
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex flex-col bg-black"
+      onClick={(e) => { if (e.target === e.currentTarget) onClose(); }}
+    >
+      {/* Header */}
+      <div className="relative flex shrink-0 items-center justify-between px-4 py-3">
+        <span className="text-sm text-white/60">
+          {index + 1} / {items.length}
+        </span>
+        <button
+          type="button"
+          onClick={onClose}
+          className="rounded-full p-2 text-white/80 hover:bg-white/10 hover:text-white"
+          aria-label="Close"
+        >
+          <X className="h-5 w-5" />
+        </button>
+      </div>
+
+      {/* Slide track */}
+      <div
+        className="relative min-h-0 flex-1 overflow-hidden"
+        onTouchStart={onTouchStart}
+        onTouchMove={onTouchMove}
+        onTouchEnd={onTouchEnd}
+        style={{ touchAction: "pan-y" }}
+        ref={trackRef}
+      >
+        <div
+          className="flex h-full"
+          style={{
+            width: `${items.length * 100}%`,
+            transform: `translateX(calc(${-index * 100 / items.length}% + ${dragX / items.length}px))`,
+            transition: isDragging ? "none" : "transform 320ms cubic-bezier(0.25, 0.46, 0.45, 0.94)",
+            willChange: "transform",
+          }}
+        >
+          {items.map((it, i) => (
+            <div
+              key={it.id}
+              className="flex h-full items-center justify-center"
+              style={{ width: `${100 / items.length}%` }}
+            >
+              {Math.abs(i - index) <= 1 && (
+                // eslint-disable-next-line @next/next/no-img-element
+                <img
+                  src={it.preview}
+                  alt={it.title || it.id}
+                  className="max-h-full max-w-full object-contain select-none"
+                  draggable={false}
+                />
+              )}
+            </div>
+          ))}
+        </div>
+
+        {/* Desktop prev/next arrows */}
+        {index > 0 && (
+          <button
+            type="button"
+            onClick={() => goTo(index - 1)}
+            className="absolute left-3 top-1/2 hidden -translate-y-1/2 rounded-full bg-black/50 p-2 text-white hover:bg-black/70 sm:flex"
+            aria-label="Previous"
+          >
+            <ChevronLeft className="h-6 w-6" />
+          </button>
+        )}
+        {index < items.length - 1 && (
+          <button
+            type="button"
+            onClick={() => goTo(index + 1)}
+            className="absolute right-3 top-1/2 hidden -translate-y-1/2 rounded-full bg-black/50 p-2 text-white hover:bg-black/70 sm:flex"
+            aria-label="Next"
+          >
+            <ChevronRight className="h-6 w-6" />
+          </button>
+        )}
+      </div>
+
+      {/* Footer: dots + action link */}
+      <div className="shrink-0 flex flex-col items-center gap-3 px-4 py-4">
+        {/* Dot indicators */}
+        {items.length > 1 && (
+          <div className="flex gap-1.5">
+            {items.map((_, i) => (
+              <button
+                key={i}
+                type="button"
+                onClick={() => goTo(i)}
+                className={`h-1.5 rounded-full transition-all ${
+                  i === index ? "w-4 bg-white" : "w-1.5 bg-white/40"
+                }`}
+                aria-label={`Go to image ${i + 1}`}
+              />
+            ))}
+          </div>
+        )}
+        <Link
+          href={exampleHref}
+          className="rounded-full bg-white/90 px-5 py-2 text-sm font-bold text-neutral-900 shadow backdrop-blur-sm hover:bg-white"
+        >
+          View prompt →
+        </Link>
+      </div>
+    </div>
+  );
+}
+
+// ── Card ────────────────────────────────────────────────────────────────────
+
 function ExampleImageCard({
   item,
   locale,
+  onOpenLightbox,
 }: {
   item: Item;
   locale: string;
+  onOpenLightbox: () => void;
 }) {
   const trackClick = useClickTracking(`${item.templateId}:${item.id}`, "nano_inspiration_example_grid", "cards");
   const { trackAction } = useTracking();
@@ -110,10 +314,11 @@ function ExampleImageCard({
 
   return (
     <div className="group overflow-hidden rounded-3xl border border-neutral-200 bg-white shadow-sm transition-all duration-200 hover:-translate-y-0.5 hover:shadow-md">
-      <Link
-        href={`/${locale}/nano-template/${toSlug(item.templateId)}/example/${encodeURIComponent(item.id)}`}
-        onClick={trackClick}
-        className="block relative overflow-hidden"
+      <button
+        type="button"
+        onClick={() => { trackClick(); onOpenLightbox(); }}
+        className="block relative overflow-hidden w-full"
+        aria-label={item.title || item.id}
       >
         <CdnImage
           src={item.preview}
@@ -126,7 +331,7 @@ function ExampleImageCard({
             View prompt →
           </span>
         </div>
-      </Link>
+      </button>
 
       <div className="flex items-center justify-between px-3 py-2">
         {item.batch ? (
@@ -175,6 +380,8 @@ function ExampleImageCard({
   );
 }
 
+// ── Grid ────────────────────────────────────────────────────────────────────
+
 export default function ExampleImagesGrid({
   items,
   maxRows = 3,
@@ -190,21 +397,21 @@ export default function ExampleImagesGrid({
   const limit = cols * maxRows;
 
   const [expanded, setExpanded] = useState(false);
+  const [lightboxIndex, setLightboxIndex] = useState<number | null>(null);
 
   const visible = expanded ? items : items.slice(0, limit);
 
   return (
     <div>
       <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-5">
-
-      {visible.map((it) => (
-  <ExampleImageCard
-    key={it.id}
-    item={{ ...it, batch }}
-    locale={locale}
-  />
-))}
-
+        {visible.map((it, i) => (
+          <ExampleImageCard
+            key={it.id}
+            item={{ ...it, batch }}
+            locale={locale}
+            onOpenLightbox={() => setLightboxIndex(expanded ? i : i)}
+          />
+        ))}
       </div>
 
       {items.length > limit && (
@@ -217,6 +424,15 @@ export default function ExampleImagesGrid({
             {expanded ? "See less" : `See more (${items.length - limit})`}
           </button>
         </div>
+      )}
+
+      {lightboxIndex !== null && (
+        <Lightbox
+          items={visible}
+          initialIndex={lightboxIndex}
+          locale={locale}
+          onClose={() => setLightboxIndex(null)}
+        />
       )}
     </div>
   );


### PR DESCRIPTION
Tapping an image card now opens a full-screen lightbox instead of navigating away. Supports real-time touch swipe with rubber-band edges, spring easing on release, dot indicators, keyboard nav, and desktop arrows.