### PR TITLE
Search relevance, watermark sync, data + missing-file fixes

### DIFF
--- a/app/[locale]/(app)/workspace/actions.ts
+++ b/app/[locale]/(app)/workspace/actions.ts
@@ -1,0 +1,62 @@
+"use server";
+
+import nanoImages from "@/public/data/nano_inspiration.json";
+import { toSlug } from "@/lib/nano_utils";
+
+export type ResolvedCard = {
+  id: string;
+  image_url: string;
+  preview_image_url: string;
+  title: string;
+  slug: string;
+  locale: string;
+};
+
+/**
+ * Resolve a list of nano_inspiration IDs (or template-level IDs, or
+ * compound "templateId:imageId" strings) into renderable cards.
+ *
+ * Lives in a server action so the 1MB nano_inspiration.json catalog stays
+ * out of the client bundle — Workspace was importing it directly.
+ */
+export async function resolveNanoIds(
+  ids: string[],
+  locale: string
+): Promise<ResolvedCard[]> {
+  const all = nanoImages as any[];
+  const imageMap = new Map(all.map((r) => [r.id, r]));
+
+  // template ID → first image (for template-level saves from NanoInspirationCard)
+  const templateFirstImageMap = new Map<string, any>();
+  for (const r of all) {
+    if (!templateFirstImageMap.has(r.template_id)) {
+      templateFirstImageMap.set(r.template_id, r);
+    }
+  }
+
+  return ids
+    .map((id) => {
+      // Case 1: compound "templateId:imageId" from ExampleImagesGrid
+      let r: any = null;
+      if (id.includes(":")) {
+        const imageId = id.split(":").slice(1).join(":");
+        r = imageMap.get(imageId);
+      }
+      // Case 2: plain image ID
+      if (!r) r = imageMap.get(id);
+      // Case 3: template ID → first image
+      if (!r) r = templateFirstImageMap.get(id);
+      if (!r) return null;
+
+      const loc = r.locales?.[locale] ?? r.locales?.en ?? r.locales?.zh ?? {};
+      return {
+        id: r.id,
+        image_url: r.asset.image_url,
+        preview_image_url: r.asset.preview_image_url,
+        title: loc.title || loc.category || id,
+        slug: toSlug(r.template_id),
+        locale,
+      };
+    })
+    .filter(Boolean) as ResolvedCard[];
+}

--- a/app/[locale]/(public)/search/SearchResultsClient.tsx
+++ b/app/[locale]/(public)/search/SearchResultsClient.tsx
@@ -6,7 +6,7 @@ import { Search } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { useTranslations } from "next-intl";
 import CdnImage from "@/app/[locale]/_components/CdnImage";
-import { filterSuggestions } from "@/lib/searchIndex";
+import type { SuggestionEntry } from "@/lib/searchIndex";
 
 type InspRecord = {
   id: string;
@@ -20,11 +20,17 @@ type Props = {
   query: string;
   locale: string;
   inspirations: InspRecord[];
+  relatedTopics: SuggestionEntry[];
 };
 
 const CDN_BASE = process.env.NEXT_PUBLIC_CDN_BASE ?? "https://cdn.curify-ai.com";
 
-export default function SearchResultsClient({ query, locale, inspirations }: Props) {
+export default function SearchResultsClient({
+  query,
+  locale,
+  inspirations,
+  relatedTopics,
+}: Props) {
   const [input, setInput] = useState(query);
   const router = useRouter();
   const t = useTranslations("topics");
@@ -48,12 +54,6 @@ export default function SearchResultsClient({ query, locale, inspirations }: Pro
       return true;
     });
   }, [inspirations]);
-
-  // Related topic suggestions (locale-aware)
-  const relatedTopics = useMemo(
-    () => filterSuggestions(query, 6, localize),
-    [query, localize]
-  );
 
   const handleSearch = (e: React.FormEvent) => {
     e.preventDefault();

--- a/app/[locale]/(public)/search/page.tsx
+++ b/app/[locale]/(public)/search/page.tsx
@@ -1,8 +1,28 @@
 import { redirect } from "next/navigation";
 import type { Metadata } from "next";
 import nanoInspiration from "@/public/data/nano_inspiration.json";
-import { ALL_SUGGESTIONS } from "@/lib/searchIndex";
+import nanoTemplates from "@/public/data/nano_templates.json";
+import {
+  ALL_SUGGESTIONS,
+  TIER2_SUGGESTIONS,
+  type SuggestionEntry,
+} from "@/lib/searchIndex";
 import SearchResultsClient from "./SearchResultsClient";
+
+// Build once per request — small enough to recompute, big enough we don't want
+// to do it inside the inspiration loop.
+const SUGGESTION_BY_SLUG = new Map<string, SuggestionEntry>(
+  ALL_SUGGESTIONS.map((s) => [s.slug, s])
+);
+const TIER_2_3_SLUGS = new Set(
+  ALL_SUGGESTIONS.filter((s) => s.tier !== 1).map((s) => s.slug)
+);
+const TEMPLATE_TOPICS = new Map<string, string[]>();
+for (const t of nanoTemplates as any[]) {
+  if (typeof t?.id === "string" && Array.isArray(t.topics)) {
+    TEMPLATE_TOPICS.set(t.id, t.topics);
+  }
+}
 
 type Props = {
   params: Promise<{ locale: string }>;
@@ -77,11 +97,34 @@ export default async function SearchPage({ params, searchParams }: Props) {
     })
     .slice(0, 80);
 
+  // Related queries: aggregate Tier-2/3 topics across matched templates,
+  // sort by frequency, fall back to popular Tier-2 if nothing matched.
+  const matchedTemplateIds = new Set(inspirations.map((r) => r.template_id));
+  const topicCounts = new Map<string, number>();
+  for (const tid of matchedTemplateIds) {
+    for (const slug of TEMPLATE_TOPICS.get(tid) ?? []) {
+      if (!TIER_2_3_SLUGS.has(slug)) continue;
+      if (slug === query) continue; // don't suggest the query back to the user
+      topicCounts.set(slug, (topicCounts.get(slug) ?? 0) + 1);
+    }
+  }
+
+  let relatedTopics: SuggestionEntry[] = [...topicCounts.entries()]
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, 8)
+    .map(([slug]) => SUGGESTION_BY_SLUG.get(slug))
+    .filter((s): s is SuggestionEntry => !!s);
+
+  if (relatedTopics.length === 0) {
+    relatedTopics = TIER2_SUGGESTIONS.filter((s) => s.slug !== query).slice(0, 8);
+  }
+
   return (
     <SearchResultsClient
       query={query}
       locale={locale}
       inspirations={inspirations}
+      relatedTopics={relatedTopics}
     />
   );
 }

--- a/app/[locale]/_components/SearchBar.tsx
+++ b/app/[locale]/_components/SearchBar.tsx
@@ -73,7 +73,7 @@ export default function SearchBar({ locale }: Props) {
     <div ref={containerRef} className="relative w-full">
       <form onSubmit={handleSubmit}>
         <div className="relative flex items-center">
-          <Search className="absolute left-3.5 h-4 w-4 text-neutral-400 pointer-events-none" />
+          <Search className="absolute left-4 h-5 w-5 text-blue-500 pointer-events-none" />
           <input
             ref={inputRef}
             type="text"
@@ -81,15 +81,15 @@ export default function SearchBar({ locale }: Props) {
             onChange={(e) => setQuery(e.target.value)}
             onFocus={() => setOpen(true)}
             placeholder="Search templates, styles, topics…"
-            className="w-full rounded-xl border border-neutral-200 bg-white py-2.5 pl-10 pr-9 text-sm text-neutral-800 placeholder:text-neutral-400 focus:border-blue-400 focus:outline-none focus:ring-2 focus:ring-blue-100 transition-all"
+            className="w-full rounded-2xl border-2 border-blue-200 bg-white py-3.5 pl-12 pr-10 text-base text-neutral-900 placeholder:text-neutral-500 shadow-sm hover:border-blue-300 focus:border-blue-500 focus:outline-none focus:ring-4 focus:ring-blue-100 transition-all"
           />
           {query && (
             <button
               type="button"
               onClick={() => { setQuery(""); inputRef.current?.focus(); }}
-              className="absolute right-3 text-neutral-400 hover:text-neutral-600"
+              className="absolute right-3.5 rounded-full p-0.5 text-neutral-400 hover:bg-neutral-100 hover:text-neutral-700"
             >
-              <X className="h-3.5 w-3.5" />
+              <X className="h-4 w-4" />
             </button>
           )}
         </div>

--- a/public/data/nano_inspiration.json
+++ b/public/data/nano_inspiration.json
@@ -32086,8 +32086,7 @@
       "health",
       "educational",
       "comparison",
-      "sports",
-      "french"
+      "sports"
     ]
   },
   {
@@ -32110,8 +32109,7 @@
       "health",
       "educational",
       "comparison",
-      "sports",
-      "french"
+      "sports"
     ]
   },
   {
@@ -32134,8 +32132,7 @@
       "health",
       "educational",
       "comparison",
-      "sports",
-      "french"
+      "sports"
     ]
   },
   {
@@ -32158,8 +32155,7 @@
       "health",
       "educational",
       "comparison",
-      "sports",
-      "french"
+      "sports"
     ]
   },
   {
@@ -32182,8 +32178,7 @@
       "health",
       "educational",
       "comparison",
-      "sports",
-      "french"
+      "sports"
     ]
   },
   {
@@ -33375,8 +33370,7 @@
       "health",
       "educational",
       "comparison",
-      "sports",
-      "french"
+      "sports"
     ]
   },
   {
@@ -33401,7 +33395,6 @@
       "comparison",
       "sports",
       "science",
-      "french",
       "anatomy"
     ]
   },
@@ -33425,8 +33418,7 @@
       "health",
       "educational",
       "comparison",
-      "sports",
-      "french"
+      "sports"
     ]
   },
   {
@@ -33450,8 +33442,7 @@
       "educational",
       "comparison",
       "sports",
-      "chinese",
-      "french"
+      "chinese"
     ]
   },
   {
@@ -35859,8 +35850,7 @@
       "educational",
       "infographic",
       "comparison",
-      "business",
-      "french"
+      "business"
     ]
   },
   {
@@ -35882,8 +35872,7 @@
       "cultural",
       "educational",
       "infographic",
-      "comparison",
-      "french"
+      "comparison"
     ]
   },
   {
@@ -35907,8 +35896,7 @@
       "infographic",
       "comparison",
       "food",
-      "lifestyle",
-      "french"
+      "lifestyle"
     ]
   },
   {
@@ -35931,7 +35919,6 @@
       "educational",
       "infographic",
       "comparison",
-      "french",
       "festival"
     ]
   },
@@ -35952,8 +35939,7 @@
       "language",
       "educational",
       "illustration",
-      "comparison",
-      "french"
+      "comparison"
     ]
   },
   {
@@ -35973,8 +35959,7 @@
       "language",
       "educational",
       "illustration",
-      "comparison",
-      "french"
+      "comparison"
     ]
   },
   {
@@ -35994,8 +35979,7 @@
       "language",
       "educational",
       "illustration",
-      "comparison",
-      "french"
+      "comparison"
     ]
   },
   {
@@ -36015,8 +35999,7 @@
       "language",
       "educational",
       "illustration",
-      "comparison",
-      "french"
+      "comparison"
     ]
   },
   {
@@ -36036,8 +36019,7 @@
       "language",
       "educational",
       "illustration",
-      "comparison",
-      "french"
+      "comparison"
     ]
   },
   {

--- a/scripts/lib/watermark.cjs
+++ b/scripts/lib/watermark.cjs
@@ -1,0 +1,136 @@
+/**
+ * Shared watermark helpers for image scripts.
+ *
+ * Backed by ImageMagick 7 (`magick` CLI). Two modes:
+ *   - applyTiledWatermark: low-opacity slanted curify logo tiled across the image.
+ *   - applyCornerWatermark: small opaque logo in the bottom-right corner.
+ *
+ * Used by:
+ *   - scripts/watermark_template_images.cjs (one-off batch by template_id)
+ *   - scripts/sync_nano_inspiration.cjs (in-line during ingest before CDN upload)
+ */
+
+const fs = require('fs');
+const path = require('path');
+const { execSync } = require('child_process');
+
+const DEFAULT_LOGO_PATH = path.join(__dirname, '..', '..', 'public', 'logo.svg');
+
+// Tiled-mode defaults
+const TILE_DEFAULTS = {
+  logoPct: 0.22,        // logo width as fraction of image width
+  spacingFactor: 1.8,   // canvas extent multiple of logo, controls gap between tiles
+  opacity: 0.15,        // 0–1
+  rotate: -30,          // degrees
+};
+
+// Corner-mode defaults
+const CORNER_DEFAULTS = {
+  logoPctFull: 0.20,
+  logoPctPreview: 0.20,
+  paddingFull: 20,
+  paddingPreview: 10,
+};
+
+function imageWidth(filePath) {
+  return parseInt(
+    execSync(`magick identify -format "%w" "${filePath}"`).toString().trim(),
+    10
+  );
+}
+
+function imageDims(filePath) {
+  return execSync(`magick identify -format "%wx%h" "${filePath}"`).toString().trim();
+}
+
+/**
+ * Tile a slanted, low-opacity logo across the source image.
+ *
+ * @param {string} srcPath
+ * @param {string} destPath - may equal srcPath to overwrite in place
+ * @param {object} [opts]
+ * @param {string} [opts.logoPath]      override DEFAULT_LOGO_PATH
+ * @param {number} [opts.logoPct]       fraction of image width (default 0.22)
+ * @param {number} [opts.spacingFactor] tile spacing multiple (default 1.8)
+ * @param {number} [opts.opacity]       0–1 (default 0.15)
+ * @param {number} [opts.rotate]        degrees (default -30)
+ */
+function applyTiledWatermark(srcPath, destPath, opts = {}) {
+  const logoPath = opts.logoPath || DEFAULT_LOGO_PATH;
+  const cfg = { ...TILE_DEFAULTS, ...opts };
+
+  const w = imageWidth(srcPath);
+  const logoPx = Math.round(w * cfg.logoPct);
+
+  const tmpLogo = destPath + '_tile_logo.png';
+  const tmpOverlay = destPath + '_overlay.png';
+
+  try {
+    // Step 1: resize, rotate, and apply opacity to the logo
+    execSync(
+      `magick -background none "${logoPath}" -resize ${logoPx}x ` +
+        `-rotate ${cfg.rotate} -alpha set -channel A -evaluate multiply ${cfg.opacity} +channel ` +
+        `"${tmpLogo}"`,
+      { stdio: 'pipe' }
+    );
+
+    // Step 1.5: extend canvas around the logo to control tile spacing
+    const [lw, lh] = imageDims(tmpLogo).split('x').map(Number);
+    const paddedW = Math.round(lw * cfg.spacingFactor);
+    const paddedH = Math.round(lh * cfg.spacingFactor);
+    execSync(
+      `magick "${tmpLogo}" -gravity center -background none -extent ${paddedW}x${paddedH} "${tmpLogo}"`,
+      { stdio: 'pipe' }
+    );
+
+    // Step 2: tile the prepared logo to source dimensions
+    execSync(
+      `magick -size ${imageDims(srcPath)} tile:"${tmpLogo}" "${tmpOverlay}"`,
+      { stdio: 'pipe' }
+    );
+
+    // Step 3: composite onto source — write to destPath (may equal srcPath)
+    execSync(
+      `magick "${srcPath}" "${tmpOverlay}" -composite "${destPath}"`,
+      { stdio: 'pipe' }
+    );
+  } finally {
+    for (const f of [tmpLogo, tmpOverlay]) {
+      try { fs.unlinkSync(f); } catch (_) {}
+    }
+  }
+}
+
+/**
+ * Drop the curify logo opaquely into the bottom-right corner.
+ *
+ * @param {string} srcPath
+ * @param {string} destPath
+ * @param {object} [opts]
+ * @param {string} [opts.logoPath]
+ * @param {number} [opts.logoPct]   fraction of image width
+ * @param {number} [opts.padding]   pixels from the edge
+ */
+function applyCornerWatermark(srcPath, destPath, opts = {}) {
+  const logoPath = opts.logoPath || DEFAULT_LOGO_PATH;
+  const w = imageWidth(srcPath);
+  const logoPct = opts.logoPct ?? CORNER_DEFAULTS.logoPctFull;
+  const padding = opts.padding ?? CORNER_DEFAULTS.paddingFull;
+  const logoPx = Math.round(w * logoPct);
+
+  execSync(
+    `magick "${srcPath}" ` +
+      `\\( -background none "${logoPath}" -resize ${logoPx}x \\) ` +
+      `-gravity SouthEast -geometry +${padding}+${padding} ` +
+      `-composite "${destPath}"`,
+    { stdio: 'pipe' }
+  );
+}
+
+module.exports = {
+  applyTiledWatermark,
+  applyCornerWatermark,
+  DEFAULT_LOGO_PATH,
+  TILE_DEFAULTS,
+  CORNER_DEFAULTS,
+};

--- a/scripts/sync_nano_inspiration.cjs
+++ b/scripts/sync_nano_inspiration.cjs
@@ -5,6 +5,7 @@ const fsp = require("fs/promises");
 const path = require("path");
 const os = require("os");
 const { execSync } = require("child_process");
+const { applyTiledWatermark } = require("./lib/watermark.cjs");
 
 // --- Load .env.local (and .env as fallback) from repo root ---
 (function loadEnv() {
@@ -281,6 +282,10 @@ async function copyFileIfNeeded(src, dst, dryRun) {
   await ensureDir(path.dirname(dst));
   if (dryRun) return;
   await fsp.copyFile(src, dst);
+  // Apply slanted curify watermark to the full image in place. The preview
+  // is generated from this file later, so it inherits the watermark too —
+  // no separate preview-watermark call needed.
+  applyTiledWatermark(dst, dst);
 }
 
 async function generatePreviewWithSizeCap(srcPath, outPath, dryRun) {

--- a/scripts/watermark_template_images.cjs
+++ b/scripts/watermark_template_images.cjs
@@ -16,27 +16,19 @@ const fs = require('fs');
 const path = require('path');
 const { execSync } = require('child_process');
 const os = require('os');
+const {
+  applyTiledWatermark,
+  applyCornerWatermark,
+  CORNER_DEFAULTS,
+} = require('./lib/watermark.cjs');
 
 // ── Config ────────────────────────────────────────────────────────────────────
 
 const CDN_BASE      = 'https://cdn.curify-ai.com';
 const GCS_BUCKET    = 'gs://curify-static';
-const LOGO_PATH     = path.join(__dirname, '../public/logo.svg');
 const INSP_JSON     = path.join(__dirname, '../public/data/nano_inspiration.json');
 const LOCAL_INSP_DIR    = path.join(__dirname, '../public/images/nano_insp');
 const LOCAL_PREVIEW_DIR = path.join(__dirname, '../public/images/nano_insp_preview');
-
-// Logo width as % of image width for full and preview sizes
-const LOGO_PCT_FULL    = 0.20;
-const LOGO_PCT_PREVIEW = 0.20;
-const PADDING_FULL     = 20;
-const PADDING_PREVIEW  = 10;
-
-// Tiled mode config
-const TILE_LOGO_PCT      = 0.22;  // logo width as % of image width
-const TILE_SPACING_FACTOR = 1.8;  // canvas extended to this multiple of logo size for spacing
-const TILE_OPACITY        = 0.15;  // 0–1, opacity of each tile
-const TILE_ROTATE         = -30;   // degrees
 
 // ── Args ──────────────────────────────────────────────────────────────────────
 
@@ -73,62 +65,6 @@ function downloadImage(url, dest) {
   execSync(`curl -sf "${url}" -o "${dest}"`, { stdio: 'pipe' });
 }
 
-function getWidth(filePath) {
-  const out = execSync(`magick identify -format "%w" "${filePath}"`).toString().trim();
-  return parseInt(out, 10);
-}
-
-function overlayLogo(srcPath, destPath, logoPx, padding) {
-  execSync(
-    `magick "${srcPath}" ` +
-    `\\( -background none "${LOGO_PATH}" -resize ${logoPx}x \\) ` +
-    `-gravity SouthEast -geometry +${padding}+${padding} ` +
-    `-composite "${destPath}"`,
-    { stdio: 'pipe' }
-  );
-}
-
-function overlayLogoTiled(srcPath, destPath, logoPx) {
-  const tmpLogo    = destPath + '_tile_logo.png';
-  const tmpOverlay = destPath + '_overlay.png';
-  try {
-    // Step 1: resize, rotate, and set opacity on the logo
-    execSync(
-      `magick -background none "${LOGO_PATH}" -resize ${logoPx}x ` +
-      `-rotate ${TILE_ROTATE} -alpha set -channel A -evaluate multiply ${TILE_OPACITY} +channel ` +
-      `"${tmpLogo}"`,
-      { stdio: 'pipe' }
-    );
-
-    // Step 1.5: extend canvas for spacing between tiles
-    const logoDims = execSync(`magick identify -format "%wx%h" "${tmpLogo}"`).toString().trim();
-    const [lw, lh] = logoDims.split('x').map(Number);
-    const paddedW = Math.round(lw * TILE_SPACING_FACTOR);
-    const paddedH = Math.round(lh * TILE_SPACING_FACTOR);
-    execSync(
-      `magick "${tmpLogo}" -gravity center -background none -extent ${paddedW}x${paddedH} "${tmpLogo}"`,
-      { stdio: 'pipe' }
-    );
-
-    // Step 2: tile the prepared logo to match source image dimensions
-    const dims = execSync(`magick identify -format "%wx%h" "${srcPath}"`).toString().trim();
-    execSync(
-      `magick -size ${dims} tile:"${tmpLogo}" "${tmpOverlay}"`,
-      { stdio: 'pipe' }
-    );
-
-    // Step 3: composite overlay onto source
-    execSync(
-      `magick "${srcPath}" "${tmpOverlay}" -composite "${destPath}"`,
-      { stdio: 'pipe' }
-    );
-  } finally {
-    for (const f of [tmpLogo, tmpOverlay]) {
-      try { fs.unlinkSync(f); } catch (_) {}
-    }
-  }
-}
-
 function uploadToGcs(localPath, gcsPath) {
   execSync(`gsutil -o "GSUtil:parallel_process_count=1" cp "${localPath}" "${gcsPath}"`, { stdio: 'inherit' });
 }
@@ -158,15 +94,13 @@ for (const record of images) {
 
       downloadImage(fullUrl, srcFile);
 
-      const w      = getWidth(srcFile);
-
       if (mode === 'tiled') {
-        const logoPx = Math.round(w * TILE_LOGO_PCT);
-        overlayLogoTiled(srcFile, destFile, logoPx);
+        applyTiledWatermark(srcFile, destFile);
       } else {
-        const logoPx = Math.round(w * (isPreview ? LOGO_PCT_PREVIEW : LOGO_PCT_FULL));
-        const pad    = isPreview ? PADDING_PREVIEW : PADDING_FULL;
-        overlayLogo(srcFile, destFile, logoPx, pad);
+        applyCornerWatermark(srcFile, destFile, {
+          logoPct: isPreview ? CORNER_DEFAULTS.logoPctPreview : CORNER_DEFAULTS.logoPctFull,
+          padding: isPreview ? CORNER_DEFAULTS.paddingPreview : CORNER_DEFAULTS.paddingFull,
+        });
       }
       uploadToGcs(destFile, gcsTarget);
 


### PR DESCRIPTION
- workspace/actions.ts: ship the server action that 7e1dc7c forgot (WorkspaceClientPage imports `./actions` but the file was never pushed, so /workspace currently fails to build on origin).
- /search related queries: aggregate Tier-2/3 topics across the matched templates and show top 8 as related-query chips; fall back to popular Tier-2 when nothing matched. Server-derived, passed in as a prop instead of the old query-substring derivation.
- SearchBar visual refresh: thicker blue-tinted border, larger blue search icon, shadow + bigger focus ring so the bar reads as a primary CTA in SiteTopBar.
- nano_inspiration.json: strip spurious "french" tag from 18 records (posture-correctness, east-asian-culture, language-word- comparison) where it was clearly mis-applied by an auto-tagger.
- scripts/lib/watermark.cjs: extract slanted+corner watermark helpers into a shared module.
- scripts/watermark_template_images.cjs: refactor to consume the shared module — same CLI surface.
- scripts/sync_nano_inspiration.cjs: apply slanted watermark in place to each new full image during ingest; preview inherits it via sharp resize, so no double-watermark.