### PR TITLE
Routed media carousel for grid clicks (image + video, circular, autop…

### DIFF
--- a/app/[locale]/(public)/nano-template/[slug]/ExampleImagesGrid.tsx
+++ b/app/[locale]/(public)/nano-template/[slug]/ExampleImagesGrid.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import { useEffect, useRef, useState, useCallback } from "react";
+import { useEffect, useRef, useState } from "react";
 import Link from "next/link";
-import { Bookmark, Download, Play, Sparkles, X, ChevronLeft, ChevronRight } from "lucide-react";
+import { Bookmark, Download, Play, Sparkles } from "lucide-react";
 import { useAtom } from "jotai";
 import { useTranslations } from "next-intl";
 import CdnImage from "@/app/[locale]/_components/CdnImage";
@@ -44,226 +44,14 @@ function useCols() {
   return cols;
 }
 
-// ── Lightbox ────────────────────────────────────────────────────────────────
-
-function Lightbox({
-  items,
-  initialIndex,
-  locale,
-  onClose,
-}: {
-  items: Item[];
-  initialIndex: number;
-  locale: string;
-  onClose: () => void;
-}) {
-  const [index, setIndex] = useState(initialIndex);
-  const [dragX, setDragX] = useState(0);
-  const [isDragging, setIsDragging] = useState(false);
-  const touchStartX = useRef(0);
-  const touchStartY = useRef(0);
-  const dragStartX = useRef(0);
-  const isHorizontalSwipe = useRef<boolean | null>(null);
-  const trackRef = useRef<HTMLDivElement>(null);
-
-  // Lock body scroll
-  useEffect(() => {
-    const prev = document.body.style.overflow;
-    document.body.style.overflow = "hidden";
-    return () => { document.body.style.overflow = prev; };
-  }, []);
-
-  // Keyboard navigation
-  useEffect(() => {
-    const onKey = (e: KeyboardEvent) => {
-      if (e.key === "Escape") onClose();
-      if (e.key === "ArrowRight") goTo(index + 1);
-      if (e.key === "ArrowLeft") goTo(index - 1);
-    };
-    window.addEventListener("keydown", onKey);
-    return () => window.removeEventListener("keydown", onKey);
-  });
-
-  const goTo = useCallback((next: number) => {
-    setIndex(Math.max(0, Math.min(items.length - 1, next)));
-    setDragX(0);
-  }, [items.length]);
-
-  // Touch handlers
-  const onTouchStart = (e: React.TouchEvent) => {
-    touchStartX.current = e.touches[0].clientX;
-    touchStartY.current = e.touches[0].clientY;
-    dragStartX.current = e.touches[0].clientX;
-    isHorizontalSwipe.current = null;
-    setIsDragging(true);
-  };
-
-  const onTouchMove = (e: React.TouchEvent) => {
-    const dx = e.touches[0].clientX - touchStartX.current;
-    const dy = e.touches[0].clientY - touchStartY.current;
-
-    // Determine swipe direction on first meaningful move
-    if (isHorizontalSwipe.current === null && (Math.abs(dx) > 4 || Math.abs(dy) > 4)) {
-      isHorizontalSwipe.current = Math.abs(dx) > Math.abs(dy);
-    }
-
-    if (!isHorizontalSwipe.current) return;
-
-    e.preventDefault();
-
-    const raw = e.touches[0].clientX - dragStartX.current;
-    // Rubber-band at edges
-    const atStart = index === 0 && raw > 0;
-    const atEnd = index === items.length - 1 && raw < 0;
-    setDragX(atStart || atEnd ? raw * 0.15 : raw);
-  };
-
-  const onTouchEnd = () => {
-    setIsDragging(false);
-    if (!isHorizontalSwipe.current) { setDragX(0); return; }
-
-    const threshold = window.innerWidth * 0.25;
-    if (dragX < -threshold && index < items.length - 1) {
-      goTo(index + 1);
-    } else if (dragX > threshold && index > 0) {
-      goTo(index - 1);
-    } else {
-      setDragX(0);
-    }
-  };
-
-  const item = items[index];
-  const exampleHref = `/${locale}/nano-template/${toSlug(item.templateId)}/example/${encodeURIComponent(item.id)}`;
-  const lightboxVideoTracking = useVideoTracking(
-    `${item.templateId}:${item.id}`,
-    "nano_inspiration_example_grid",
-    "cards"
-  );
-
-  return (
-    <div
-      className="fixed inset-0 z-50 flex flex-col bg-black"
-      onClick={(e) => { if (e.target === e.currentTarget) onClose(); }}
-    >
-      {/* Header */}
-      <div className="relative flex shrink-0 items-center justify-between px-4 py-3">
-        <span className="text-sm text-white/60">
-          {index + 1} / {items.length}
-        </span>
-        <button
-          type="button"
-          onClick={onClose}
-          className="rounded-full p-2 text-white/80 hover:bg-white/10 hover:text-white"
-          aria-label="Close"
-        >
-          <X className="h-5 w-5" />
-        </button>
-      </div>
-
-      {/* Slide track */}
-      <div
-        className="relative min-h-0 flex-1 overflow-hidden"
-        onTouchStart={onTouchStart}
-        onTouchMove={onTouchMove}
-        onTouchEnd={onTouchEnd}
-        style={{ touchAction: "pan-y" }}
-        ref={trackRef}
-      >
-        <div
-          className="flex h-full"
-          style={{
-            width: `${items.length * 100}%`,
-            transform: `translateX(calc(${-index * 100 / items.length}% + ${dragX / items.length}px))`,
-            transition: isDragging ? "none" : "transform 320ms cubic-bezier(0.25, 0.46, 0.45, 0.94)",
-            willChange: "transform",
-          }}
-        >
-          {items.map((it, i) => (
-            <div
-              key={it.id}
-              className="flex h-full items-center justify-center"
-              style={{ width: `${100 / items.length}%` }}
-            >
-              {Math.abs(i - index) <= 1 && (
-                <div className="relative h-full w-full">
-                  <CdnImage
-                    src={it.preview}
-                    alt={it.title || it.id}
-                    fill
-                    className="object-contain select-none"
-                    draggable={false}
-                  />
-                </div>
-              )}
-            </div>
-          ))}
-        </div>
-
-        {/* Desktop prev/next arrows */}
-        {index > 0 && (
-          <button
-            type="button"
-            onClick={() => goTo(index - 1)}
-            className="absolute left-3 top-1/2 hidden -translate-y-1/2 rounded-full bg-black/50 p-2 text-white hover:bg-black/70 sm:flex"
-            aria-label="Previous"
-          >
-            <ChevronLeft className="h-6 w-6" />
-          </button>
-        )}
-        {index < items.length - 1 && (
-          <button
-            type="button"
-            onClick={() => goTo(index + 1)}
-            className="absolute right-3 top-1/2 hidden -translate-y-1/2 rounded-full bg-black/50 p-2 text-white hover:bg-black/70 sm:flex"
-            aria-label="Next"
-          >
-            <ChevronRight className="h-6 w-6" />
-          </button>
-        )}
-      </div>
-
-      {/* Footer: dots + action link */}
-      <div className="shrink-0 flex flex-col items-center gap-3 px-4 py-4">
-        {/* Dot indicators */}
-        {items.length > 1 && (
-          <div className="flex gap-1.5">
-            {items.map((_, i) => (
-              <button
-                key={i}
-                type="button"
-                onClick={() => goTo(i)}
-                className={`h-1.5 rounded-full transition-all ${
-                  i === index ? "w-4 bg-white" : "w-1.5 bg-white/40"
-                }`}
-                aria-label={`Go to image ${i + 1}`}
-              />
-            ))}
-          </div>
-        )}
-        <Link
-          href={exampleHref}
-          onClick={() => {
-            if (item.videoUrl) lightboxVideoTracking.trackVideoClick();
-          }}
-          className="rounded-full bg-white/90 px-5 py-2 text-sm font-bold text-neutral-900 shadow backdrop-blur-sm hover:bg-white"
-        >
-          View prompt →
-        </Link>
-      </div>
-    </div>
-  );
-}
-
 // ── Card ────────────────────────────────────────────────────────────────────
 
 function ExampleImageCard({
   item,
   locale,
-  onOpenLightbox,
 }: {
   item: Item;
   locale: string;
-  onOpenLightbox: () => void;
 }) {
   const trackClick = useClickTracking(`${item.templateId}:${item.id}`, "nano_inspiration_example_grid", "cards");
   const { trackVideoClick } = useVideoTracking(`${item.templateId}:${item.id}`, "nano_inspiration_example_grid", "cards");
@@ -277,6 +65,12 @@ function ExampleImageCard({
   const [saved, setSaved] = useState(false);
   const [showSavedToast, setShowSavedToast] = useState(false);
 
+  const tracking = {
+    contentId: `${item.templateId}:${item.id}`,
+    contentType: "nano_inspiration_example_grid" as const,
+    viewMode: "cards" as const,
+  };
+
   const handleSave = (e: React.MouseEvent) => {
     e.preventDefault();
     if (saved) return;
@@ -287,18 +81,14 @@ function ExampleImageCard({
     setTimeout(() => setShowSavedToast(false), 3000);
   };
 
-  const tracking = {
-    contentId: `${item.templateId}:${item.id}`,
-    contentType: "nano_inspiration_example_grid" as const,
-    viewMode: "cards" as const,
-  };
-
   const remixHref = (() => {
     const qs = item.params && Object.keys(item.params).length > 0
       ? `?${new URLSearchParams(item.params).toString()}`
       : "";
     return `/${locale}/nano-template/${toSlug(item.templateId)}${qs}#reproduce`;
   })();
+
+  const carouselHref = `/${locale}/nano-template/${toSlug(item.templateId)}/carousel/${encodeURIComponent(item.id)}?media=${hasVideo ? "video" : "image"}`;
 
   const handleDownload = async (e: React.MouseEvent) => {
     e.preventDefault();
@@ -328,14 +118,10 @@ function ExampleImageCard({
   return (
     <div className="group overflow-hidden rounded-3xl border border-neutral-200 bg-white shadow-sm transition-all duration-200 hover:-translate-y-0.5 hover:shadow-md">
       <Link
-        href={`/${locale}/nano-template/${toSlug(item.templateId)}/example/${encodeURIComponent(item.id)}`}
-        onClick={(e) => {
+        href={carouselHref}
+        onClick={() => {
           trackClick();
           if (hasVideo) trackVideoClick();
-          if (window.matchMedia("(pointer: coarse)").matches) {
-            e.preventDefault();
-            onOpenLightbox();
-          }
         }}
         className="block relative overflow-hidden"
       >
@@ -355,7 +141,7 @@ function ExampleImageCard({
         )}
         <div className="absolute inset-0 flex items-end justify-center bg-black/0 pb-4 opacity-0 transition-colors duration-200 group-hover:bg-black/20 group-hover:opacity-100">
           <span className="rounded-full bg-white/90 px-4 py-1.5 text-xs font-bold text-neutral-900 shadow backdrop-blur-sm">
-            View prompt →
+            {hasVideo ? "Play video →" : "View prompt →"}
           </span>
         </div>
       </Link>
@@ -424,19 +210,17 @@ export default function ExampleImagesGrid({
   const limit = cols * maxRows;
 
   const [expanded, setExpanded] = useState(false);
-  const [lightboxIndex, setLightboxIndex] = useState<number | null>(null);
 
   const visible = expanded ? items : items.slice(0, limit);
 
   return (
     <div>
       <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-5">
-        {visible.map((it, i) => (
+        {visible.map((it) => (
           <ExampleImageCard
             key={it.id}
             item={{ ...it, batch }}
             locale={locale}
-            onOpenLightbox={() => setLightboxIndex(i)}
           />
         ))}
       </div>
@@ -451,15 +235,6 @@ export default function ExampleImagesGrid({
             {expanded ? "See less" : `See more (${items.length - limit})`}
           </button>
         </div>
-      )}
-
-      {lightboxIndex !== null && (
-        <Lightbox
-          items={visible}
-          initialIndex={lightboxIndex}
-          locale={locale}
-          onClose={() => setLightboxIndex(null)}
-        />
       )}
     </div>
   );

--- a/app/[locale]/(public)/nano-template/[slug]/carousel/[exampleId]/CarouselClient.tsx
+++ b/app/[locale]/(public)/nano-template/[slug]/carousel/[exampleId]/CarouselClient.tsx
@@ -1,0 +1,307 @@
+"use client";
+
+import { useState, useRef, useEffect, useCallback } from "react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { X, ChevronLeft, ChevronRight } from "lucide-react";
+
+import ProgressiveCdnImage from "@/app/[locale]/_components/ProgressiveCdnImage";
+import ExampleVideoPlayer from "../../example/[exampleId]/ExampleVideoPlayer";
+import { useTracking } from "@/services/useTracking";
+
+type Slide = {
+  id: string;
+  title: string;
+  templateId: string;
+  imageUrl: string;
+  previewImageUrl?: string;
+  videoUrl?: string;
+};
+
+type Props = {
+  slides: Slide[];
+  initialIndex: number;
+  locale: string;
+  slug: string;
+  media: "image" | "video";
+};
+
+export default function CarouselClient({
+  slides,
+  initialIndex,
+  locale,
+  slug,
+  media,
+}: Props) {
+  const router = useRouter();
+  const [index, setIndex] = useState(initialIndex);
+  const [dragX, setDragX] = useState(0);
+  const [isDragging, setIsDragging] = useState(false);
+  // Set to false to skip the slide-track transition for one frame — used
+  // when wrapping around so the carousel doesn't visibly fly across every
+  // slide between the edges.
+  const [animate, setAnimate] = useState(true);
+  const touchStartX = useRef(0);
+  const touchStartY = useRef(0);
+  const dragStartX = useRef(0);
+  const isHorizontalSwipe = useRef<boolean | null>(null);
+  const trackedSlides = useRef<Set<string>>(new Set());
+  const { track } = useTracking();
+
+  const slide = slides[index];
+
+  const goTo = useCallback(
+    (next: number) => {
+      const len = slides.length;
+      if (len === 0) return;
+      const wrapped = ((next % len) + len) % len;
+      const isWrap = Math.abs(wrapped - index) > 1;
+      if (isWrap) setAnimate(false);
+      setIndex(wrapped);
+      setDragX(0);
+    },
+    [slides.length, index]
+  );
+
+  // Re-enable transitions one frame after a wrap so subsequent moves animate.
+  useEffect(() => {
+    if (animate) return;
+    const raf = requestAnimationFrame(() => setAnimate(true));
+    return () => cancelAnimationFrame(raf);
+  }, [animate]);
+
+  const close = useCallback(() => {
+    if (!slide) {
+      router.push(`/${locale}/nano-template/${slug}`);
+      return;
+    }
+    router.push(
+      `/${locale}/nano-template/${slug}/example/${encodeURIComponent(slide.id)}`
+    );
+  }, [router, locale, slug, slide]);
+
+  // Body scroll lock while in carousel
+  useEffect(() => {
+    const prev = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+    return () => {
+      document.body.style.overflow = prev;
+    };
+  }, []);
+
+  // Keep URL in sync with current slide so the link is shareable, but use
+  // history.replaceState (not router.push) so back-button exits the carousel
+  // rather than walking through every slide.
+  useEffect(() => {
+    if (!slide) return;
+    const url = `/${locale}/nano-template/${slug}/carousel/${encodeURIComponent(slide.id)}?media=${media}`;
+    window.history.replaceState(null, "", url);
+  }, [slide, locale, slug, media]);
+
+  // Track view per unique slide visited
+  useEffect(() => {
+    if (!slide) return;
+    if (trackedSlides.current.has(slide.id)) return;
+    trackedSlides.current.add(slide.id);
+    track({
+      contentId: `${slide.templateId}:${slide.id}`,
+      contentType: "nano_inspiration_example_grid",
+      actionType: "view",
+      viewMode: "cards",
+    });
+  }, [slide, track]);
+
+  // Keyboard navigation
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") close();
+      else if (e.key === "ArrowRight") goTo(index + 1);
+      else if (e.key === "ArrowLeft") goTo(index - 1);
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [index, close, goTo]);
+
+  // Touch swipe (ported from the previous in-grid Lightbox)
+  const onTouchStart = (e: React.TouchEvent) => {
+    touchStartX.current = e.touches[0].clientX;
+    touchStartY.current = e.touches[0].clientY;
+    dragStartX.current = e.touches[0].clientX;
+    isHorizontalSwipe.current = null;
+    setIsDragging(true);
+  };
+
+  const onTouchMove = (e: React.TouchEvent) => {
+    const dx = e.touches[0].clientX - touchStartX.current;
+    const dy = e.touches[0].clientY - touchStartY.current;
+    if (
+      isHorizontalSwipe.current === null &&
+      (Math.abs(dx) > 4 || Math.abs(dy) > 4)
+    ) {
+      isHorizontalSwipe.current = Math.abs(dx) > Math.abs(dy);
+    }
+    if (!isHorizontalSwipe.current) return;
+    e.preventDefault();
+    const raw = e.touches[0].clientX - dragStartX.current;
+    setDragX(raw);
+  };
+
+  const onTouchEnd = () => {
+    setIsDragging(false);
+    if (!isHorizontalSwipe.current) {
+      setDragX(0);
+      return;
+    }
+    const threshold = window.innerWidth * 0.25;
+    if (dragX < -threshold) goTo(index + 1);
+    else if (dragX > threshold) goTo(index - 1);
+    else setDragX(0);
+  };
+
+  if (!slide) return null;
+
+  const exampleHref = `/${locale}/nano-template/${slug}/example/${encodeURIComponent(slide.id)}`;
+  const stopPropagation = (e: React.MouseEvent) => e.stopPropagation();
+
+  return (
+    // Click anywhere outside an interactive element or media → go to prompt page.
+    // Internal media + buttons stop propagation so they keep their own behavior.
+    <div className="fixed inset-0 z-50 flex flex-col bg-black" onClick={close}>
+      {/* Header */}
+      <div className="flex shrink-0 items-center justify-between px-4 py-3">
+        <span className="text-sm text-white/60">
+          {index + 1} / {slides.length}
+        </span>
+        <button
+          type="button"
+          onClick={(e) => {
+            e.stopPropagation();
+            close();
+          }}
+          className="rounded-full p-2 text-white/80 hover:bg-white/10 hover:text-white"
+          aria-label="Close"
+        >
+          <X className="h-5 w-5" />
+        </button>
+      </div>
+
+      {/* Slide track */}
+      <div
+        className="relative min-h-0 flex-1 overflow-hidden"
+        onTouchStart={onTouchStart}
+        onTouchMove={onTouchMove}
+        onTouchEnd={onTouchEnd}
+        style={{ touchAction: "pan-y" }}
+      >
+        <div
+          className="flex h-full"
+          style={{
+            width: `${slides.length * 100}%`,
+            transform: `translateX(calc(${(-index * 100) / slides.length}% + ${dragX / slides.length}px))`,
+            transition: isDragging || !animate
+              ? "none"
+              : "transform 320ms cubic-bezier(0.25, 0.46, 0.45, 0.94)",
+            willChange: "transform",
+          }}
+        >
+          {slides.map((s, i) => {
+            const isActive = i === index;
+            return (
+              <div
+                key={s.id}
+                className="flex h-full items-center justify-center"
+                style={{ width: `${100 / slides.length}%` }}
+              >
+                {Math.abs(i - index) <= 1 && (
+                  <div
+                    className="relative flex h-full w-full items-center justify-center p-2"
+                    onClick={stopPropagation}
+                  >
+                    {media === "video" && s.videoUrl ? (
+                      <ExampleVideoPlayer
+                        key={s.id}
+                        templateId={s.templateId}
+                        exampleId={s.id}
+                        videoUrl={s.videoUrl}
+                        posterUrl={s.previewImageUrl ?? s.imageUrl}
+                        title={s.title}
+                        active={isActive}
+                        autoPlay
+                      />
+                    ) : (
+                      <ProgressiveCdnImage
+                        previewSrc={s.previewImageUrl}
+                        fullSrc={s.imageUrl}
+                        alt={s.title || s.id}
+                        className="h-full w-full object-contain select-none"
+                        priority={isActive}
+                        noZoom
+                      />
+                    )}
+                  </div>
+                )}
+              </div>
+            );
+          })}
+        </div>
+
+        {/* Desktop prev/next arrows — always rendered (carousel wraps) */}
+        {slides.length > 1 && (
+          <>
+            <button
+              type="button"
+              onClick={(e) => {
+                e.stopPropagation();
+                goTo(index - 1);
+              }}
+              className="absolute left-3 top-1/2 hidden -translate-y-1/2 rounded-full bg-black/50 p-2 text-white hover:bg-black/70 sm:flex"
+              aria-label="Previous"
+            >
+              <ChevronLeft className="h-6 w-6" />
+            </button>
+            <button
+              type="button"
+              onClick={(e) => {
+                e.stopPropagation();
+                goTo(index + 1);
+              }}
+              className="absolute right-3 top-1/2 hidden -translate-y-1/2 rounded-full bg-black/50 p-2 text-white hover:bg-black/70 sm:flex"
+              aria-label="Next"
+            >
+              <ChevronRight className="h-6 w-6" />
+            </button>
+          </>
+        )}
+      </div>
+
+      {/* Footer: dots + view-prompt link */}
+      <div className="shrink-0 flex flex-col items-center gap-3 px-4 py-4">
+        {slides.length > 1 && slides.length <= 12 && (
+          <div className="flex gap-1.5">
+            {slides.map((_, i) => (
+              <button
+                key={i}
+                type="button"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  goTo(i);
+                }}
+                className={`h-1.5 rounded-full transition-all ${
+                  i === index ? "w-4 bg-white" : "w-1.5 bg-white/40"
+                }`}
+                aria-label={`Go to slide ${i + 1}`}
+              />
+            ))}
+          </div>
+        )}
+        <Link
+          href={exampleHref}
+          onClick={stopPropagation}
+          className="rounded-full bg-white/90 px-5 py-2 text-sm font-bold text-neutral-900 shadow backdrop-blur-sm hover:bg-white"
+        >
+          View prompt →
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/app/[locale]/(public)/nano-template/[slug]/carousel/[exampleId]/page.tsx
+++ b/app/[locale]/(public)/nano-template/[slug]/carousel/[exampleId]/page.tsx
@@ -1,0 +1,76 @@
+import { notFound } from "next/navigation";
+
+import CarouselClient from "./CarouselClient";
+import {
+  buildNanoPageContext,
+  getImageViewsForTemplate,
+} from "@/lib/nano_page_data";
+
+type PageParams = {
+  locale: string;
+  slug: string;
+  exampleId: string;
+};
+
+type SearchParams = {
+  media?: string;
+};
+
+export default async function NanoCarouselPage({
+  params,
+  searchParams,
+}: {
+  params: Promise<PageParams>;
+  searchParams: Promise<SearchParams>;
+}) {
+  const { locale, slug, exampleId: rawExampleId } = await params;
+  const { media } = await searchParams;
+
+  const isVideo = media === "video";
+  const exampleId = decodeURIComponent(rawExampleId);
+
+  const ctx = await buildNanoPageContext(locale, slug);
+  const all = getImageViewsForTemplate(
+    ctx.reg,
+    ctx.templateId,
+    ctx.contentLocale
+  );
+
+  const filtered = isVideo
+    ? all.filter((x) => Boolean(x.video_url))
+    : all.filter((x) => !x.video_url);
+
+  if (filtered.length === 0) notFound();
+
+  const idxInFiltered = filtered.findIndex((x) => x.id === exampleId);
+  const fallbackIdx = all.findIndex((x) => x.id === exampleId);
+
+  // If the entry exampleId isn't in the filtered set, fall back to the unfiltered list
+  // so the user lands on the example they clicked.
+  const slidesSource = idxInFiltered === -1 && fallbackIdx !== -1 ? all : filtered;
+  const initialIndex =
+    idxInFiltered !== -1
+      ? idxInFiltered
+      : fallbackIdx !== -1
+      ? fallbackIdx
+      : 0;
+
+  const slides = slidesSource.map((s) => ({
+    id: s.id,
+    title: s.title ?? "",
+    templateId: s.template_id,
+    imageUrl: s.image_url,
+    previewImageUrl: s.preview_image_url,
+    videoUrl: s.video_url,
+  }));
+
+  return (
+    <CarouselClient
+      slides={slides}
+      initialIndex={initialIndex}
+      locale={locale}
+      slug={slug}
+      media={isVideo ? "video" : "image"}
+    />
+  );
+}

--- a/app/[locale]/(public)/nano-template/[slug]/example/[exampleId]/ExampleVideoPlayer.tsx
+++ b/app/[locale]/(public)/nano-template/[slug]/example/[exampleId]/ExampleVideoPlayer.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useRef } from "react";
+import { useEffect, useRef } from "react";
 import { cdn } from "@/lib/cdn";
 import { useVideoTracking } from "@/services/useTracking";
 
@@ -10,6 +10,10 @@ type Props = {
   videoUrl: string;
   posterUrl?: string;
   title?: string;
+  /** True when this player is the currently visible slide. Defaults to true. */
+  active?: boolean;
+  /** Auto-play (muted) when active. Defaults to false. */
+  autoPlay?: boolean;
 };
 
 export default function ExampleVideoPlayer({
@@ -18,7 +22,10 @@ export default function ExampleVideoPlayer({
   videoUrl,
   posterUrl,
   title,
+  active = true,
+  autoPlay = false,
 }: Props) {
+  const videoRef = useRef<HTMLVideoElement>(null);
   const playFired = useRef(false);
   const { trackVideoPlay } = useVideoTracking(
     `${templateId}:${exampleId}`,
@@ -26,8 +33,28 @@ export default function ExampleVideoPlayer({
     "cards"
   );
 
+  useEffect(() => {
+    const v = videoRef.current;
+    if (!v) return;
+    if (active && autoPlay) {
+      // Try unmuted first (preserves sound when allowed); if the browser
+      // blocks it (autoplay policy), fall back to muted so the video at
+      // least starts playing — user can unmute via controls.
+      v.muted = false;
+      v.play().catch(() => {
+        v.muted = true;
+        v.play().catch(() => {
+          // Even muted autoplay denied; leave paused, user can press play.
+        });
+      });
+    } else if (!active) {
+      v.pause();
+    }
+  }, [active, autoPlay]);
+
   return (
     <video
+      ref={videoRef}
       src={cdn(videoUrl)}
       poster={posterUrl ? cdn(posterUrl) : undefined}
       controls

--- a/app/[locale]/_components/ProgressiveCdnImage.tsx
+++ b/app/[locale]/_components/ProgressiveCdnImage.tsx
@@ -9,12 +9,14 @@ export default function ProgressiveCdnImage({
   alt,
   className = "",
   priority = false,
+  noZoom = false,
 }: {
   previewSrc?: string;
   fullSrc: string;
   alt: string;
   className?: string;
   priority?: boolean;
+  noZoom?: boolean;
 }) {
   const [src, setSrc] = useState(previewSrc || fullSrc);
   const [open, setOpen] = useState(false);
@@ -29,6 +31,19 @@ export default function ProgressiveCdnImage({
     img.onload = () => setSrc(fullSrc);
   }, [previewSrc, fullSrc]);
 
+  const inner = (
+    <CdnImage
+      src={src}
+      alt={alt}
+      className={className}
+      priority={priority}
+    />
+  );
+
+  if (noZoom) {
+    return <div className="block h-full w-full">{inner}</div>;
+  }
+
   return (
     <>
       <button
@@ -37,12 +52,7 @@ export default function ProgressiveCdnImage({
         className="block h-full w-full cursor-zoom-in"
         aria-label="Open full image"
       >
-        <CdnImage
-          src={src}
-          alt={alt}
-          className={className}
-          priority={priority}
-        />
+        {inner}
       </button>
 
       {open && (

--- a/services/useTracking.ts
+++ b/services/useTracking.ts
@@ -55,6 +55,7 @@ const SESSION_KEY = "_curify_session_id";
 const LOCALE_PREFIX = /^\/[a-z]{2}(?=\/|$)/;
 
 const ROUTE_PATTERNS: [RegExp, string][] = [
+  [/\/nano-template\/[^/]+\/carousel\/[^/]+$/, "/nano-template/[slug]/carousel/[exampleId]"],
   [/\/nano-template\/[^/]+\/example\/[^/]+$/, "/nano-template/[slug]/example/[exampleId]"],
   [/\/nano-template\/[^/]+$/,                 "/nano-template/[slug]"],
   [/\/nano-banana-pro-prompts\/tag\/[^/]+$/,  "/nano-banana-pro-prompts/tag/[slug]"],


### PR DESCRIPTION
…lay)

Replaces the in-grid lightbox modal with a routed carousel at /nano-template/[slug]/carousel/[exampleId]?media=image|video so both desktop and mobile share the same browse experience and the URL is shareable. Image tiles open an image carousel filtered to non-video examples; video tiles (with the existing play badge) open a video carousel filtered to videos only. The active video slide auto-plays unmuted on entry and falls back to muted if the browser blocks it.

Carousel UX: circular nav (wrap from first to last and vice versa with a one-frame jump-cut so the track does not sweep across all slides), keyboard / swipe / on-screen prev-next, body scroll lock, click on the black backdrop or padding around the media routes to the example prompt page (same as the close button), per-slide URL update via history.replaceState so the back button exits to the grid.

Tracking: per-slide view fires once per unique slide visited with the existing nano_inspiration_example_grid content_type; new /nano-template/[slug]/carousel/[exampleId] route pattern added so tracking events get a distinct current_page_route. video_play still fires once per mount on each video slide via the existing playFired ref. ProgressiveCdnImage gains a noZoom prop so the carousel can reuse the preview-to-full progressive load without the zoom-modal-on-click.