### PR TITLE
Move 9-traits-info-grid topics from lifestyle/learning to character

### DIFF
--- a/public/data/nano_templates.json
+++ b/public/data/nano_templates.json
@@ -5029,8 +5029,7 @@
     },
     "og_image": "/images/nano_insp_preview/template-9-traits-info-grid-wealthy-women-prev.jpg",
     "topics": [
-      "lifestyle",
-      "learning",
+      "character",
       "comparison"
     ],
     "base_rank_score": 90,


### PR DESCRIPTION
The 9-Traits infographic templates (e.g. 9 Traits of a Quality Partner, 9 Traits of Leadership) are character-archetype content rather than lifestyle or learning, so retag accordingly. Keeps comparison.