### PR TITLE
Add reproduce sidebar to carousel and fix click-outside-image close

### DIFF
--- a/app/[locale]/(public)/nano-template/[slug]/carousel/[exampleId]/CarouselClient.tsx
+++ b/app/[locale]/(public)/nano-template/[slug]/carousel/[exampleId]/CarouselClient.tsx
@@ -5,17 +5,55 @@ import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { X, ChevronLeft, ChevronRight } from "lucide-react";
 
-import ProgressiveCdnImage from "@/app/[locale]/_components/ProgressiveCdnImage";
 import ExampleVideoPlayer from "../../example/[exampleId]/ExampleVideoPlayer";
+import ExampleRightColumn from "../../example/[exampleId]/ExampleRightColumn";
 import { useTracking } from "@/services/useTracking";
+import { cdn } from "@/lib/cdn";
+import type { TemplateParameter } from "@/lib/nano_utils";
+import type { ExistingExampleRef } from "@/lib/editDistance";
+
+// Plain <img> with preview→full progressive swap. We avoid next/image
+// here because the carousel needs the rendered <img>'s bounding box to
+// match the visible image (so clicking on dark padding bubbles to the
+// backdrop close handler rather than being captured by the img element).
+function ProgressiveSlideImage({
+  previewSrc,
+  fullSrc,
+  alt,
+}: {
+  previewSrc?: string;
+  fullSrc: string;
+  alt: string;
+}) {
+  const [src, setSrc] = useState<string>(previewSrc || fullSrc);
+  useEffect(() => {
+    setSrc(previewSrc || fullSrc);
+    if (!fullSrc || fullSrc === previewSrc) return;
+    const img = new window.Image();
+    img.src = cdn(fullSrc);
+    img.onload = () => setSrc(fullSrc);
+  }, [previewSrc, fullSrc]);
+
+  return (
+    <img
+      src={cdn(src)}
+      alt={alt}
+      draggable={false}
+      className="max-h-full max-w-full select-none"
+    />
+  );
+}
 
 type Slide = {
   id: string;
   title: string;
+  category: string;
   templateId: string;
   imageUrl: string;
   previewImageUrl?: string;
   videoUrl?: string;
+  params: Record<string, string>;
+  topics: string[];
 };
 
 type Props = {
@@ -24,6 +62,13 @@ type Props = {
   locale: string;
   slug: string;
   media: "image" | "video";
+  templateTopics: string[];
+  templateParameters: TemplateParameter[];
+  templateAllowGeneration: boolean;
+  templateBatch: boolean;
+  basePrompt: string;
+  existingExamples: ExistingExampleRef[];
+  siteUrl: string;
 };
 
 export default function CarouselClient({
@@ -32,6 +77,13 @@ export default function CarouselClient({
   locale,
   slug,
   media,
+  templateTopics,
+  templateParameters,
+  templateAllowGeneration,
+  templateBatch,
+  basePrompt,
+  existingExamples,
+  siteUrl,
 }: Props) {
   const router = useRouter();
   const [index, setIndex] = useState(initialIndex);
@@ -111,12 +163,21 @@ export default function CarouselClient({
     });
   }, [slide, track]);
 
-  // Keyboard navigation
+  // Keyboard navigation. Ignore arrow keys while focus is in an editable
+  // field (the reproduce sidebar's inputs/selects) so the user can move
+  // the cursor without flipping slides. Escape always closes.
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
+      const t = e.target as HTMLElement | null;
+      const editable =
+        !!t &&
+        (t.tagName === "INPUT" ||
+          t.tagName === "TEXTAREA" ||
+          t.tagName === "SELECT" ||
+          t.isContentEditable);
       if (e.key === "Escape") close();
-      else if (e.key === "ArrowRight") goTo(index + 1);
-      else if (e.key === "ArrowLeft") goTo(index - 1);
+      else if (!editable && e.key === "ArrowRight") goTo(index + 1);
+      else if (!editable && e.key === "ArrowLeft") goTo(index - 1);
     };
     window.addEventListener("keydown", onKey);
     return () => window.removeEventListener("keydown", onKey);
@@ -184,10 +245,13 @@ export default function CarouselClient({
     close();
   };
 
+  const examplePageUrl = `${siteUrl}/${locale}/nano-template/${slug}/example/${encodeURIComponent(slide.id)}`;
+
   return (
     // Click anywhere outside an interactive element or media → go to prompt page.
     // Internal media + buttons stop propagation so they keep their own behavior.
-    <div className="fixed inset-0 z-50 flex flex-col bg-black" onClick={onBackdropClick}>
+    <div className="fixed inset-0 z-50 flex bg-black" onClick={onBackdropClick}>
+      <div className="flex min-w-0 flex-1 flex-col">
       {/* Header */}
       <div className="flex shrink-0 items-center justify-between px-4 py-3">
         <span className="text-sm text-white/60">
@@ -237,7 +301,13 @@ export default function CarouselClient({
                 {Math.abs(i - index) <= 1 && (
                   <div
                     className="relative flex h-full w-full items-center justify-center p-2"
-                    onClick={stopPropagation}
+                    onClick={(e) => {
+                      // Only stop propagation when the click hit the media
+                      // itself (a child element). Clicks on the padding
+                      // around the media should still bubble to the
+                      // backdrop and route to the prompt page.
+                      if (e.target !== e.currentTarget) e.stopPropagation();
+                    }}
                   >
                     {media === "video" && s.videoUrl ? (
                       <ExampleVideoPlayer
@@ -251,13 +321,10 @@ export default function CarouselClient({
                         autoPlay
                       />
                     ) : (
-                      <ProgressiveCdnImage
+                      <ProgressiveSlideImage
                         previewSrc={s.previewImageUrl}
                         fullSrc={s.imageUrl}
                         alt={s.title || s.id}
-                        className="h-full w-full object-contain select-none"
-                        priority={isActive}
-                        noZoom
                       />
                     )}
                   </div>
@@ -330,6 +397,34 @@ export default function CarouselClient({
           View prompt →
         </Link>
       </div>
+      </div>
+
+      {/* Right: reproduce sidebar — desktop only, ~25% width */}
+      <aside
+        className="hidden lg:flex lg:w-80 xl:w-96 shrink-0 flex-col overflow-y-auto bg-white text-neutral-900"
+        onClick={stopPropagation}
+      >
+        <div className="px-4 py-4">
+          <ExampleRightColumn
+            key={slide.id}
+            chipTopics={templateTopics}
+            chipExampleTopics={slide.topics}
+            chipCategory={slide.category}
+            title={slide.title}
+            templateId={slide.templateId}
+            slug={slug}
+            locale={locale}
+            parameters={templateParameters}
+            allowGeneration={templateAllowGeneration}
+            initialParams={slide.params}
+            exampleId={slide.id}
+            basePrompt={basePrompt}
+            batchEnabled={templateBatch}
+            examplePageUrl={examplePageUrl}
+            existingExamples={existingExamples}
+          />
+        </div>
+      </aside>
     </div>
   );
 }

--- a/app/[locale]/(public)/nano-template/[slug]/carousel/[exampleId]/page.tsx
+++ b/app/[locale]/(public)/nano-template/[slug]/carousel/[exampleId]/page.tsx
@@ -3,8 +3,11 @@ import { notFound } from "next/navigation";
 import CarouselClient from "./CarouselClient";
 import {
   buildNanoPageContext,
-  getImageViewsForTemplate,
+  resolveLocalizedExampleCopy,
 } from "@/lib/nano_page_data";
+import { getNanoExampleById } from "@/lib/nano_example_utils";
+import { getTemplateView } from "@/lib/nano_utils";
+import { SITE_URL } from "@/lib/constants";
 
 type PageParams = {
   locale: string;
@@ -30,24 +33,21 @@ export default async function NanoCarouselPage({
   const exampleId = decodeURIComponent(rawExampleId);
 
   const ctx = await buildNanoPageContext(locale, slug);
-  const all = getImageViewsForTemplate(
-    ctx.reg,
-    ctx.templateId,
-    ctx.contentLocale
-  );
+  const rawImages = ctx.reg.imagesByTemplateId.get(ctx.templateId) ?? [];
 
   const filtered = isVideo
-    ? all.filter((x) => Boolean(x.video_url))
-    : all.filter((x) => !x.video_url);
+    ? rawImages.filter((x) => Boolean(x.asset.video_url))
+    : rawImages.filter((x) => !x.asset.video_url);
 
   if (filtered.length === 0) notFound();
 
   const idxInFiltered = filtered.findIndex((x) => x.id === exampleId);
-  const fallbackIdx = all.findIndex((x) => x.id === exampleId);
+  const fallbackIdx = rawImages.findIndex((x) => x.id === exampleId);
 
   // If the entry exampleId isn't in the filtered set, fall back to the unfiltered list
   // so the user lands on the example they clicked.
-  const slidesSource = idxInFiltered === -1 && fallbackIdx !== -1 ? all : filtered;
+  const slidesSource =
+    idxInFiltered === -1 && fallbackIdx !== -1 ? rawImages : filtered;
   const initialIndex =
     idxInFiltered !== -1
       ? idxInFiltered
@@ -55,13 +55,45 @@ export default async function NanoCarouselPage({
       ? fallbackIdx
       : 0;
 
-  const slides = slidesSource.map((s) => ({
-    id: s.id,
-    title: s.title ?? "",
-    templateId: s.template_id,
-    imageUrl: s.image_url,
-    previewImageUrl: s.preview_image_url,
-    videoUrl: s.video_url,
+  // Per-slide data (title, category, params, topics)
+  const slides = slidesSource.map((img) => {
+    const example = getNanoExampleById(
+      ctx.templateId,
+      img.id,
+      ctx.contentLocale
+    );
+    const { title, category } = example
+      ? resolveLocalizedExampleCopy(example, ctx.contentLocale, ctx.localizedEntry)
+      : { title: img.id, category: "" };
+
+    const paramEntries = Object.fromEntries(
+      Object.entries(img.params ?? {}).map(([k, v]) => [k, String(v ?? "")])
+    );
+
+    return {
+      id: img.id,
+      title,
+      category,
+      templateId: img.template_id,
+      imageUrl: img.asset.image_url,
+      previewImageUrl: img.asset.preview_image_url,
+      videoUrl: img.asset.video_url,
+      params: paramEntries,
+      topics: img.topics ?? [],
+    };
+  });
+
+  // Template-level data (constant across slides in this carousel)
+  const templateView = getTemplateView(ctx.reg, ctx.templateId, ctx.contentLocale);
+  const templateTopics = templateView?.topics ?? [];
+  const templateParameters = templateView?.parameters ?? [];
+  const templateAllowGeneration = templateView?.allow_generation ?? false;
+  const templateBatch = templateView?.batch ?? false;
+  const basePrompt = templateView?.base_prompt ?? "";
+
+  const existingExamples = rawImages.map((img) => ({
+    id: img.id,
+    params: img.params ?? {},
   }));
 
   return (
@@ -71,6 +103,13 @@ export default async function NanoCarouselPage({
       locale={locale}
       slug={slug}
       media={isVideo ? "video" : "image"}
+      templateTopics={templateTopics}
+      templateParameters={templateParameters}
+      templateAllowGeneration={templateAllowGeneration}
+      templateBatch={templateBatch}
+      basePrompt={basePrompt}
+      existingExamples={existingExamples}
+      siteUrl={SITE_URL}
     />
   );
 }


### PR DESCRIPTION
The carousel page now mounts ExampleRightColumn in a right-side aside (hidden on mobile, ~25% width on lg+, white panel keyed on slide.id so the form and generated result reset per slide). The server page loads template-level data once (topics, parameters, base_prompt, batch, allow_generation, existingExamples) and per-slide title/category/ params/topics so the sidebar can drive both the chips and a working generate flow without reloading the page when slides change.

Also fix two bugs the sidebar surfaced:

1. Click-outside-image close was caught by the slide media wrapper because the prior next/image-backed ProgressiveCdnImage rendered with h-full w-full, so its <img> bounding box filled the wrapper even when object-contain letterboxed the visible pixels. Replace it with an inline ProgressiveSlideImage that renders a plain <img> with max-h-full max-w-full so the element bbox matches the visible image; the surrounding dark bands now belong to the wrapper and bubble clicks up to the backdrop handler that routes to /example.
2. Arrow keys (left/right) navigated slides while the user was typing into the sidebar form inputs. The keyboard handler now ignores arrow keys when focus is on INPUT/TEXTAREA/SELECT or any contentEditable element. Escape still always closes.