### PR TITLE
Rename carousel footer button to "Visit template" and route to templa…

### DIFF
--- a/app/[locale]/(public)/nano-template/[slug]/carousel/[exampleId]/CarouselClient.tsx
+++ b/app/[locale]/(public)/nano-template/[slug]/carousel/[exampleId]/CarouselClient.tsx
@@ -221,7 +221,6 @@ export default function CarouselClient({
 
   if (!slide) return null;
 
-  const exampleHref = `/${locale}/nano-template/${slug}/example/${encodeURIComponent(slide.id)}`;
   const stopPropagation = (e: React.MouseEvent) => e.stopPropagation();
   const trackBrowse = (suffix: "prev" | "next" | "dot") => {
     track({
@@ -387,14 +386,14 @@ export default function CarouselClient({
           </div>
         )}
         <Link
-          href={exampleHref}
+          href={`/${locale}/nano-template/${slug}`}
           onClick={(e) => {
             e.stopPropagation();
             trackViewPrompt();
           }}
-          className="rounded-full bg-white/90 px-5 py-2 text-sm font-bold text-neutral-900 shadow backdrop-blur-sm hover:bg-white"
+          className="rounded-full border-2 border-purple-500 bg-white/90 px-5 py-2 text-sm font-bold text-purple-700 shadow backdrop-blur-sm hover:bg-white hover:border-purple-600"
         >
-          View prompt →
+          Visit template →
         </Link>
       </div>
       </div>


### PR DESCRIPTION
…te page

Change the carousel footer's primary call-to-action from "View prompt ->" (which routed to the example detail page) to "Visit template ->" that routes to /nano-template/<slug>. Style updated to a white pill with a purple-500 border and purple-700 text so the action stands out against the black backdrop.

Close button (X), backdrop click, and Escape continue to route to the example detail page, giving users two distinct exits: footer for the template overview, close for the prompt detail.

Tracking unchanged — still fires click + nano_inspiration_example_grid via trackViewPrompt() with content_id ${templateId}:${slideId}.