### PR TITLE
Surface declared-but-empty topics in the registry so chips render

### DIFF
--- a/lib/topicRegistry.ts
+++ b/lib/topicRegistry.ts
@@ -197,18 +197,42 @@ function buildTopicRegistry(): TopicRegistry {
     templateToTopics.set(t.id, normalizeTopicValues(t.topics));
   }
 
-  // Build enriched topic list (parentTopic from explicit map)
-  const allTopicIds = Array.from(topicToTemplateIds.keys());
-  const enrichedTopics: TopicWithTemplates[] = allTopicIds.map((id) => {
-    const topicTemplates = topicToTemplates.get(id) ?? [];
-    return {
-      id,
-      templates: topicTemplates,
-      templateCount: topicTemplates.length,
-      isEnabled: topicTemplates.length > 0,
-      parentTopic: EXPLICIT_PARENT_TOPIC.get(id),
-    };
-  });
+  // Collect every explicitly-declared topic id (Tier 1 keys, Tier 2
+  // navigational children, and Tier 3 tag children). Topics declared in
+  // these constants must surface in the registry — and be navigable —
+  // even before any template / inspiration has been tagged with them, so
+  // newly-added tags (e.g. food-and-drink, evolution) appear as
+  // discoverable chips on parent pages while content gets curated.
+  const declaredTopicIds = new Set<string>();
+  for (const [tier1, children] of Object.entries(EXPLICIT_CHILD_TOPICS)) {
+    declaredTopicIds.add(tier1);
+    for (const child of children) declaredTopicIds.add(child);
+  }
+  for (const [tier1, tags] of Object.entries(TIER1_TAG_CHILDREN)) {
+    declaredTopicIds.add(tier1);
+    for (const tag of tags) declaredTopicIds.add(tag);
+  }
+
+  // Build enriched topic list — union of data-derived + declared topics.
+  const allTopicIds = new Set<string>([
+    ...topicToTemplateIds.keys(),
+    ...declaredTopicIds,
+  ]);
+  const enrichedTopics: TopicWithTemplates[] = Array.from(allTopicIds).map(
+    (id) => {
+      const topicTemplates = topicToTemplates.get(id) ?? [];
+      return {
+        id,
+        templates: topicTemplates,
+        templateCount: topicTemplates.length,
+        // Declared topics are clickable even when empty — the destination
+        // page can still surface gallery prompts via TOPIC_GALLERY_TAG and
+        // sibling chips, and SEO-wise we want the chip discoverable.
+        isEnabled: topicTemplates.length > 0 || declaredTopicIds.has(id),
+        parentTopic: EXPLICIT_PARENT_TOPIC.get(id),
+      };
+    }
+  );
 
   const topicById = new Map<string, TopicWithTemplates>(
     enrichedTopics.map((t) => [t.id, t])


### PR DESCRIPTION
The topic registry only included topics that had at least one template / inspiration tagged. Newly-declared subject tags (food-and-drink, evolution, family, school, etc.) had no tagged content yet, so they never appeared in registry.topics — which made TopicNavRow's find() return undefined and silently drop the chip, even after dropping the page-level isTopicEnabled filter.

Fix at the source: in buildTopicRegistry, collect every id declared in EXPLICIT_CHILD_TOPICS and TIER1_TAG_CHILDREN into a declaredTopicIds set, then union it with the data-derived topic ids when building enrichedTopics. Mark declared topics as isEnabled even when their templateCount is 0 — they should be clickable chips (the destination page can still surface gallery prompts via TOPIC_GALLERY_TAG, sibling navigation, etc.) rather than disappear.