### PR TITLE
Narrow evolution topic to dinosaur / human-evolution science content

### DIFF
--- a/public/data/nano_inspiration.json
+++ b/public/data/nano_inspiration.json
@@ -1011,8 +1011,7 @@
     "legacy_id": "template-evolution-british-industrial-revolution",
     "legacy_template_id": "template-evolution",
     "topics": [
-      "uk",
-      "evolution"
+      "uk"
     ],
     "tags": [
       "evolution",
@@ -1046,9 +1045,7 @@
       "educational",
       "colorful"
     ],
-    "topics": [
-      "evolution"
-    ]
+    "topics": []
   },
   {
     "id": "template-evolution-chinese-social-changes",
@@ -1079,8 +1076,7 @@
       "educational"
     ],
     "topics": [
-      "china",
-      "evolution"
+      "china"
     ]
   },
   {
@@ -1356,9 +1352,7 @@
       "history",
       "educational"
     ],
-    "topics": [
-      "evolution"
-    ]
+    "topics": []
   },
   {
     "id": "template-evolution-transportation",
@@ -1382,9 +1376,7 @@
       "evolution",
       "infographic"
     ],
-    "topics": [
-      "evolution"
-    ]
+    "topics": []
   },
   {
     "id": "template-herbal-angelica",
@@ -27277,8 +27269,7 @@
     ],
     "topics": [
       "china",
-      "posters",
-      "evolution"
+      "posters"
     ]
   },
   {
@@ -27298,8 +27289,7 @@
     },
     "topics": [
       "france",
-      "posters",
-      "evolution"
+      "posters"
     ],
     "tags": [
       "history",
@@ -27326,8 +27316,7 @@
     },
     "topics": [
       "india",
-      "posters",
-      "evolution"
+      "posters"
     ],
     "tags": [
       "history",
@@ -27355,8 +27344,7 @@
     },
     "topics": [
       "japan",
-      "posters",
-      "evolution"
+      "posters"
     ],
     "tags": [
       "japanese",
@@ -27384,8 +27372,7 @@
     },
     "topics": [
       "korea",
-      "posters",
-      "evolution"
+      "posters"
     ],
     "tags": [
       "evolution",
@@ -29693,8 +29680,7 @@
       "evolution"
     ],
     "topics": [
-      "posters",
-      "evolution"
+      "posters"
     ]
   },
   {
@@ -30609,8 +30595,7 @@
     },
     "topics": [
       "uk",
-      "posters",
-      "evolution"
+      "posters"
     ],
     "tags": [
       "history",
@@ -30638,8 +30623,7 @@
     },
     "topics": [
       "egypt",
-      "posters",
-      "evolution"
+      "posters"
     ],
     "tags": [
       "history",
@@ -30666,8 +30650,7 @@
     },
     "topics": [
       "egypt",
-      "posters",
-      "evolution"
+      "posters"
     ],
     "tags": [
       "history",
@@ -30702,8 +30685,7 @@
     "topics": [
       "middle-east",
       "posters",
-      "iran",
-      "evolution"
+      "iran"
     ]
   },
   {
@@ -33762,8 +33744,7 @@
     },
     "topics": [
       "uk",
-      "posters",
-      "evolution"
+      "posters"
     ],
     "tags": [
       "history",
@@ -33794,8 +33775,7 @@
     },
     "topics": [
       "egypt",
-      "posters",
-      "evolution"
+      "posters"
     ],
     "tags": [
       "history",
@@ -33835,8 +33815,7 @@
     ],
     "topics": [
       "russia",
-      "posters",
-      "evolution"
+      "posters"
     ]
   },
   {
@@ -34296,8 +34275,7 @@
     ],
     "topics": [
       "germany",
-      "posters",
-      "evolution"
+      "posters"
     ]
   },
   {
@@ -34327,8 +34305,7 @@
     ],
     "topics": [
       "greece",
-      "posters",
-      "evolution"
+      "posters"
     ]
   },
   {
@@ -34348,8 +34325,7 @@
     },
     "topics": [
       "italy",
-      "posters",
-      "evolution"
+      "posters"
     ],
     "tags": [
       "history",
@@ -34379,8 +34355,7 @@
     },
     "topics": [
       "mexico",
-      "posters",
-      "evolution"
+      "posters"
     ],
     "tags": [
       "history",
@@ -40377,9 +40352,7 @@
         "title": "apple inc"
       }
     },
-    "topics": [
-      "evolution"
-    ]
+    "topics": []
   },
   {
     "id": "template-history-timeline-infographic-coffee-history",
@@ -40396,9 +40369,7 @@
         "title": "coffee history"
       }
     },
-    "topics": [
-      "evolution"
-    ]
+    "topics": []
   },
   {
     "id": "template-history-timeline-infographic-film-awards",
@@ -40415,9 +40386,7 @@
         "title": "film awards"
       }
     },
-    "topics": [
-      "evolution"
-    ]
+    "topics": []
   },
   {
     "id": "template-history-timeline-infographic-photography",
@@ -40434,9 +40403,7 @@
         "title": "photography"
       }
     },
-    "topics": [
-      "evolution"
-    ]
+    "topics": []
   },
   {
     "id": "template-history-timeline-infographic-space-exploration",
@@ -40453,9 +40420,7 @@
         "title": "space exploration"
       }
     },
-    "topics": [
-      "evolution"
-    ]
+    "topics": []
   },
   {
     "id": "template-history-timeline-infographic-video-games-evolution",
@@ -40472,9 +40437,7 @@
         "title": "video games evolution"
       }
     },
-    "topics": [
-      "evolution"
-    ]
+    "topics": []
   },
   {
     "id": "template-history-timeline-infographic-vintage-fashion",
@@ -40491,9 +40454,7 @@
         "title": "vintage fashion"
       }
     },
-    "topics": [
-      "evolution"
-    ]
+    "topics": []
   },
   {
     "id": "template-pop-culture-matching-chart-mbti-coffee",


### PR DESCRIPTION
Drop evolution tag from inspirations under broad change-over-time templates: template-clothing-evolution-poster (per-country clothing shifts), template-nostalgic-first-item-poster (first TV, first car etc.), template-evolution (industrial revolution / currency forms / art development / social changes / transportation evolution), and template-history-timeline-infographic (generic topic timelines).

These were swept in earlier on the broader interpretation that "change over time" = evolution, but the topic display name is "Dinosaur & Evolution" which signals a tighter scope: prehistoric / hominid / biological-science-style evolution content for kids education. Generic product / fashion / cultural timelines belong in nostalgia or history rather than evolution.

Net evolution-tagged inspirations: 31 -> 2
  - template-word-scene-student-dinosaur-jungle
  - template-science-education-infographic-human-evolution