### PR TITLE
Bump example sitemap lastmod for i18n SEO copy; add MBTI tags to char…

### DIFF
--- a/app/sitemap-examples.xml/route.ts
+++ b/app/sitemap-examples.xml/route.ts
@@ -6,6 +6,7 @@ import { toSlug } from "@/lib/nano_utils";
 import {
   SEO_RETITLED_LASTMOD,
   SEO_RETITLED_TEMPLATE_IDS,
+  I18N_DESCRIPTIONS_LASTMOD,
 } from "@/lib/seo_retitled_templates";
 
 export const runtime = "nodejs";
@@ -122,10 +123,16 @@ export async function GET() {
       toSlug(templateId)
     )}/example/${encodeURIComponent(exampleId)}`;
 
-    // If the parent template was retitled in the SEO pass, bump the
-    // lastmod for every one of its examples so Google recrawls the
-    // example pages too (they render the same i18n title as the h1).
-    const lastmod = SEO_RETITLED_TEMPLATE_IDS.has(templateId)
+    // Lastmod priority:
+    //  1. allow_i18n examples — bumped to the i18n descriptions ship date
+    //     so Google re-crawls and picks up the new per-locale copy + the
+    //     8 added locale URL variants.
+    //  2. Examples whose parent template was retitled in the SEO pass —
+    //     bumped to that pass's date so the new h1 is recrawled.
+    //  3. Fallback to the example's own updated_at / lastmod, or STABLE.
+    const lastmod = ex.allow_i18n
+      ? I18N_DESCRIPTIONS_LASTMOD
+      : SEO_RETITLED_TEMPLATE_IDS.has(templateId)
       ? SEO_RETITLED_LASTMOD
       : pickLastmod(ex) ?? STABLE_LASTMOD;
 

--- a/app/sitemap-index.xml/route.ts
+++ b/app/sitemap-index.xml/route.ts
@@ -4,26 +4,23 @@ export const runtime = "nodejs";
 
 const BASE_URL = "https://www.curify-ai.com";
 
-// Children — every sitemap registered here is auto-discovered by search
-// engines that read /sitemap-index.xml. Update this list when new sitemap
-// files are added under app/sitemap-*.xml/route.ts.
-const CHILD_SITEMAPS = [
-  "/sitemap.xml",
-  "/sitemap-blogs.xml",
-  "/sitemap-examples.xml",
+// Per-child lastmod — bump the entry whose contents materially changed so
+// Google re-fetches that child sitemap. Each child sitemap also carries
+// its own per-URL lastmods inside, which Google trusts more than this.
+const CHILD_SITEMAPS: Array<{ path: string; lastmod: string }> = [
+  { path: "/sitemap.xml",          lastmod: "2026-05-08T00:00:00.000Z" },
+  { path: "/sitemap-blogs.xml",    lastmod: "2026-05-08T00:00:00.000Z" },
+  // Bumped 2026-05-07 — 260 example pages gained per-locale SEO copy
+  // (title / description / metaDescription) and 8 new locale URL variants.
+  { path: "/sitemap-examples.xml", lastmod: "2026-05-07T00:00:00.000Z" },
 ];
-
-// Static lastmod for the index. The child sitemaps each carry their own
-// per-URL lastmods (which Google trusts more), so this is just a coarse
-// hint that the index itself was reviewed recently. Bump as needed.
-const INDEX_LASTMOD = "2026-05-08T00:00:00.000Z";
 
 export async function GET() {
   const entries = CHILD_SITEMAPS.map(
-    (path) => `
+    ({ path, lastmod }) => `
     <sitemap>
       <loc>${BASE_URL}${path}</loc>
-      <lastmod>${INDEX_LASTMOD}</lastmod>
+      <lastmod>${lastmod}</lastmod>
     </sitemap>`
   ).join("");
 

--- a/lib/seo_retitled_templates.ts
+++ b/lib/seo_retitled_templates.ts
@@ -9,6 +9,12 @@
 
 export const SEO_RETITLED_LASTMOD = "2026-05-05T00:00:00.000Z";
 
+// Bump lastmod for the 260 allow_i18n example pages whose per-locale
+// SEO copy (title / description / metaDescription) shipped on 2026-05-07.
+// These pages also gained 8 new locale URL variants in the sitemap, so
+// signaling Google to re-fetch is worthwhile.
+export const I18N_DESCRIPTIONS_LASTMOD = "2026-05-07T00:00:00.000Z";
+
 export const SEO_RETITLED_TEMPLATE_IDS: ReadonlySet<string> = new Set([
   "template-gardening-how-to-infographic",
   "template-pet-care-guide",

--- a/lib/topicRegistry.ts
+++ b/lib/topicRegistry.ts
@@ -48,6 +48,13 @@ function normalizeTopicValues(value: unknown): string[] {
   return [];
 }
 
+const MBTI_TYPE_TAGS = [
+  "mbti-intj","mbti-intp","mbti-entj","mbti-entp",
+  "mbti-infj","mbti-infp","mbti-enfj","mbti-enfp",
+  "mbti-istj","mbti-isfj","mbti-estj","mbti-esfj",
+  "mbti-istp","mbti-isfp","mbti-estp","mbti-esfp",
+];
+
 // Explicit sibling groups for tag-style topics (geo, language pairs, visual styles, subjects, personality).
 // These appear at the bottom of topic pages as related tags.
 const EXPLICIT_SIBLING_GROUPS: string[][] = [
@@ -55,7 +62,7 @@ const EXPLICIT_SIBLING_GROUPS: string[][] = [
   ["english-chinese", "english-spanish", "english-korean", "english-japanese", "english-french"],
   ["cartoon", "kawaii", "ink", "isometric", "photorealistic", "monochrome", "watercolor"],
   ["animals", "nature", "space", "weather"],
-  ["mbti-intj","mbti-intp","mbti-entj","mbti-entp","mbti-infj","mbti-infp","mbti-enfj","mbti-enfp","mbti-istj","mbti-isfj","mbti-estj","mbti-esfj","mbti-istp","mbti-isfp","mbti-estp","mbti-esfp"],
+  MBTI_TYPE_TAGS,
   ["minimalist", "soft-girl", "edgy", "athleisure", "chic", "vintage-retro", "elegant", "casual", "high-fashion"],
 ];
 
@@ -76,7 +83,11 @@ const SUBJECT_TAGS = [
 // Tier 1 → Tier 3 tag children mapping.
 // These tags appear at the bottom of the Tier 1 topic page.
 const TIER1_TAG_CHILDREN: Record<string, string[]> = {
-  personality: ["mbti-intj","mbti-intp","mbti-entj","mbti-entp","mbti-infj","mbti-infp","mbti-enfj","mbti-enfp","mbti-istj","mbti-isfj","mbti-estj","mbti-esfj","mbti-istp","mbti-isfp","mbti-estp","mbti-esfp"],
+  personality: MBTI_TYPE_TAGS,
+  // character also surfaces the 16 MBTI types as bottom-row tag chips
+  // (in addition to its Tier 2 nav children), since MBTI character cards
+  // are one of the strongest entry points for the character Tier 1.
+  character:   MBTI_TYPE_TAGS,
   travel:      ["spain", "france", "india", "japan", "korea", "thailand", "mexico", "uk", "brazil", "vietnam", "singapore", "egypt", "australia", "italy", "middle-east", "china", "germany", "greece", "russia", "united-states", "iran", "portugal"],
   // language pairs (english-chinese etc.) were promoted to Tier 2 so they
   // sit alongside vocabulary/dialogue/expressions/language-english as


### PR DESCRIPTION
…acter

- Bump <lastmod> to 2026-05-07 for the 260 allow_i18n example pages so Google re-crawls and picks up the per-locale SEO copy + 8 new locale URL variants. Refactor sitemap-index to per-child lastmod so only the examples sitemap signals freshness.
- Surface the 16 MBTI type tag chips on the /topic/character Tier 1 page too (already on /topic/personality). Factor MBTI_TYPE_TAGS so the two stay in sync. Side effect: Tier 1 ancestor for mbti-* tags now resolves to character, giving those Tier 3 pages character's nav subtopics.