### PR TITLE
Replace example-grid Save with Remix+Share; ease mobile carousel swipe

### DIFF
--- a/app/[locale]/(public)/nano-template/[slug]/ExampleImagesGrid.tsx
+++ b/app/[locale]/(public)/nano-template/[slug]/ExampleImagesGrid.tsx
@@ -2,10 +2,12 @@
 
 import { useEffect, useRef, useState } from "react";
 import Link from "next/link";
-import { Bookmark, Download, Play, Sparkles } from "lucide-react";
+import { Download, Play, Sparkles } from "lucide-react";
 import { useAtom } from "jotai";
 import { useTranslations } from "next-intl";
 import CdnImage from "@/app/[locale]/_components/CdnImage";
+import ShareButton from "@/app/[locale]/_components/ShareButton";
+import { SITE_URL } from "@/lib/constants";
 import { toSlug } from "@/lib/nano_utils";
 import { useClickTracking, useTracking, useVideoTracking } from "@/services/useTracking";
 import { templatePacksService } from "@/services/templatePacks";
@@ -62,23 +64,11 @@ function ExampleImageCard({
   const [, setDrawerState] = useAtom(drawerAtom);
   const [isDownloading, setIsDownloading] = useState(false);
   const isDownloadingRef = useRef(false);
-  const [saved, setSaved] = useState(false);
-  const [showSavedToast, setShowSavedToast] = useState(false);
 
   const tracking = {
     contentId: `${item.templateId}:${item.id}`,
     contentType: "nano_inspiration_example_grid" as const,
     viewMode: "cards" as const,
-  };
-
-  const handleSave = (e: React.MouseEvent) => {
-    e.preventDefault();
-    if (saved) return;
-    if (!user) { setDrawerState("signin"); return; }
-    setSaved(true);
-    trackAction(tracking, "favorite");
-    setShowSavedToast(true);
-    setTimeout(() => setShowSavedToast(false), 3000);
   };
 
   const remixHref = (() => {
@@ -89,6 +79,8 @@ function ExampleImageCard({
   })();
 
   const carouselHref = `/${locale}/nano-template/${toSlug(item.templateId)}/carousel/${encodeURIComponent(item.id)}?media=${hasVideo ? "video" : "image"}`;
+
+  const shareUrl = `${SITE_URL}/${locale}/nano-template/${toSlug(item.templateId)}/example/${encodeURIComponent(item.id)}`;
 
   const handleDownload = async (e: React.MouseEvent) => {
     e.preventDefault();
@@ -116,14 +108,14 @@ function ExampleImageCard({
   };
 
   return (
-    <div className="group overflow-hidden rounded-3xl border border-neutral-200 bg-white shadow-sm transition-all duration-200 hover:-translate-y-0.5 hover:shadow-md">
+    <div className="group rounded-3xl border border-neutral-200 bg-white shadow-sm transition-all duration-200 hover:-translate-y-0.5 hover:shadow-md">
       <Link
         href={carouselHref}
         onClick={() => {
           trackClick();
           if (hasVideo) trackVideoClick();
         }}
-        className="block relative overflow-hidden"
+        className="block relative overflow-hidden rounded-t-3xl"
       >
         <CdnImage
           src={item.preview}
@@ -158,36 +150,24 @@ function ExampleImageCard({
             {isDownloading ? t("downloadingPack") : t("downloadPack")}
           </button>
         ) : (
-          <div className="relative">
-            <button
-              type="button"
-              onClick={handleSave}
-              className={`flex cursor-pointer items-center gap-1.5 rounded-full px-3 py-1 text-sm font-semibold transition-colors ${
-                saved
-                  ? "bg-purple-100 text-purple-700"
-                  : "bg-neutral-100 text-neutral-700 hover:bg-neutral-200"
-              }`}
-            >
-              <Bookmark className={`h-3.5 w-3.5 ${saved ? "fill-current" : ""}`} />
-              {saved ? t("saved") : t("save")}
-            </button>
-            {showSavedToast && (
-              <div className="absolute bottom-full left-0 mb-2 whitespace-nowrap rounded-lg bg-neutral-900 px-3 py-1.5 text-xs text-white shadow-lg">
-                Saved! View in your workspace →
-              </div>
-            )}
-          </div>
+          <Link
+            href={remixHref}
+            onClick={() => {
+              document.getElementById("reproduce")?.scrollIntoView({ behavior: "smooth", block: "start" });
+            }}
+            className="flex items-center gap-1.5 rounded-full bg-purple-50 px-3 py-1 text-sm font-semibold text-purple-700 transition-colors hover:bg-purple-100 hover:text-purple-900"
+          >
+            <Sparkles className="h-3.5 w-3.5" />
+            Remix this
+          </Link>
         )}
-        <Link
-          href={remixHref}
-          onClick={() => {
-            document.getElementById("reproduce")?.scrollIntoView({ behavior: "smooth", block: "start" });
-          }}
-          className="flex items-center gap-1.5 rounded-full bg-purple-50 px-3 py-1 text-sm font-semibold text-purple-700 transition-colors hover:bg-purple-100 hover:text-purple-900"
-        >
-          <Sparkles className="h-3.5 w-3.5" />
-          Remix this
-        </Link>
+        <ShareButton
+          compact
+          url={shareUrl}
+          title={item.title || item.id}
+          text={`Check out this Nano Banana example: ${item.title || item.id}`}
+          onShared={() => trackAction(tracking, "share")}
+        />
       </div>
     </div>
   );

--- a/app/[locale]/(public)/nano-template/[slug]/carousel/[exampleId]/CarouselClient.tsx
+++ b/app/[locale]/(public)/nano-template/[slug]/carousel/[exampleId]/CarouselClient.tsx
@@ -74,6 +74,22 @@ function ZoomableSlideImage({
   const [fullLoaded, setFullLoaded] = useState(false);
   const handleFullLoaded = useCallback(() => setFullLoaded(true), []);
 
+  // Track scale locally so we can keep panning disabled at scale=1.
+  // Without this, the library swallows 1-finger drags as no-op panning
+  // and the parent's slide-swipe handler never sees the gesture, making
+  // it hard to flip slides on mobile.
+  const [scale, setScale] = useState(1);
+
+  const handleTransform = useCallback(
+    (_ref: unknown, state: { scale: number }) => {
+      setScale(state.scale);
+      onScaleChange(state.scale);
+    },
+    [onScaleChange]
+  );
+
+  const isZoomed = scale > 1.001;
+
   return (
     <TransformWrapper
       initialScale={1}
@@ -83,8 +99,11 @@ function ZoomableSlideImage({
       doubleClick={{ mode: "toggle", step: 1.5, disabled: !fullLoaded }}
       pinch={{ disabled: !fullLoaded }}
       wheel={{ step: 0.2, disabled: !fullLoaded }}
-      onTransform={(_ref, state) => onScaleChange(state.scale)}
-      panning={{ disabled: !fullLoaded, velocityDisabled: true }}
+      onTransform={handleTransform}
+      // Panning is what consumes 1-finger drags. Keep it off at scale=1 so
+      // horizontal swipes flow through to the parent slide-swipe handler;
+      // re-enable once the user has actually zoomed in.
+      panning={{ disabled: !fullLoaded || !isZoomed, velocityDisabled: true }}
     >
       <TransformComponent
         wrapperClass="!h-full !w-full !flex !items-center !justify-center"

--- a/app/[locale]/_components/ShareButton.tsx
+++ b/app/[locale]/_components/ShareButton.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import React, { useMemo, useState, useRef, useEffect } from "react";
+import { createPortal } from "react-dom";
 import { Share2, Link2, Check } from "lucide-react";
 
 type ShareButtonProps = {
@@ -9,6 +10,18 @@ type ShareButtonProps = {
   text?: string;
   className?: string;
   onShared?: () => void;
+  /**
+   * Compact mode: pill-style button with a click-toggled floating panel
+   * of social icons + copy below the button. Use inside small containers
+   * like grid cards.
+   */
+  compact?: boolean;
+  /**
+   * Fires whenever the burst panel opens or closes. Useful for the parent
+   * to bump its own z-index while the panel is visible — without that, the
+   * panel can be painted under sibling cards from the next grid row.
+   */
+  onOpenChange?: (open: boolean) => void;
 };
 
 function isMobileLikeDevice() {
@@ -97,12 +110,19 @@ export default function ShareButton({
   text,
   className = "",
   onShared,
+  compact = false,
+  onOpenChange,
 }: ShareButtonProps) {
   const [status, setStatus] = useState<"idle" | "shared" | "copied">("idle");
   const [isOpen, setIsOpen] = useState(false);
   const containerRef = useRef<HTMLDivElement>(null);
   const mainButtonRef = useRef<HTMLButtonElement>(null);
+  const panelRef = useRef<HTMLDivElement>(null);
   const closeTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  // For compact mode: anchor coords (viewport-relative, fixed positioning)
+  // computed from the main button's bounding rect so the portal-rendered
+  // panel stays glued to the button.
+  const [panelAnchor, setPanelAnchor] = useState<{ top: number; right: number } | null>(null);
 
   const prefersNativeShare = useMemo(() => {
     if (typeof window === "undefined") return false;
@@ -112,13 +132,45 @@ export default function ShareButton({
   useEffect(() => {
     if (!isOpen) return;
     const handleClickOutside = (e: MouseEvent) => {
-      if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
+      const target = e.target as Node;
+      const insideContainer = containerRef.current?.contains(target);
+      const insidePanel = panelRef.current?.contains(target);
+      if (!insideContainer && !insidePanel) {
         setIsOpen(false);
       }
     };
     document.addEventListener("mousedown", handleClickOutside);
     return () => document.removeEventListener("mousedown", handleClickOutside);
   }, [isOpen]);
+
+  useEffect(() => {
+    onOpenChange?.(isOpen);
+  }, [isOpen, onOpenChange]);
+
+  // Compact mode only: compute the panel's viewport-anchored position
+  // from the main button. Refresh on scroll/resize so it stays glued.
+  useEffect(() => {
+    if (!compact || !isOpen) {
+      setPanelAnchor(null);
+      return;
+    }
+    const update = () => {
+      const btn = mainButtonRef.current;
+      if (!btn) return;
+      const rect = btn.getBoundingClientRect();
+      setPanelAnchor({
+        top: rect.bottom + 8,
+        right: window.innerWidth - rect.right,
+      });
+    };
+    update();
+    window.addEventListener("scroll", update, true);
+    window.addEventListener("resize", update);
+    return () => {
+      window.removeEventListener("scroll", update, true);
+      window.removeEventListener("resize", update);
+    };
+  }, [compact, isOpen]);
 
   const resetStatusLater = () => {
     window.setTimeout(() => setStatus("idle"), 2500);
@@ -165,13 +217,18 @@ export default function ShareButton({
   return (
     <div
       ref={containerRef}
+      // Compact mode is click-toggled (no hover). Default mode also opens
+      // on hover for desktop discoverability.
       className={`relative inline-flex items-center ${className}`}
+      style={isOpen ? { zIndex: 30 } : undefined}
       onMouseEnter={() => {
+        if (compact) return;
         if (prefersNativeShare) return;
         if (closeTimer.current) clearTimeout(closeTimer.current);
         setIsOpen(true);
       }}
       onMouseLeave={() => {
+        if (compact) return;
         closeTimer.current = setTimeout(() => setIsOpen(false), 1500);
       }}
     >
@@ -181,21 +238,75 @@ export default function ShareButton({
         type="button"
         onClick={handleMainClick}
         style={{ position: "relative", zIndex: 20 }}
-        className={`inline-flex cursor-pointer items-center gap-2 rounded-xl border border-neutral-200 bg-white px-4 py-2 text-sm font-semibold text-neutral-800 transition-colors hover:bg-neutral-50 ${
-          isOpen ? "border-neutral-400 bg-neutral-50" : ""
-        }`}
+        className={
+          compact
+            ? `inline-flex cursor-pointer items-center gap-1.5 rounded-full px-3 py-1 text-sm font-semibold transition-colors ${
+                isOpen
+                  ? "bg-neutral-200 text-neutral-800"
+                  : "bg-neutral-100 text-neutral-700 hover:bg-neutral-200"
+              }`
+            : `inline-flex cursor-pointer items-center gap-2 rounded-xl border border-neutral-200 bg-white px-4 py-2 text-sm font-semibold text-neutral-800 transition-colors hover:bg-neutral-50 ${
+                isOpen ? "border-neutral-400 bg-neutral-50" : ""
+              }`
+        }
         aria-label="Share"
         aria-expanded={isOpen}
       >
         <Share2
-          className="h-4 w-4 transition-transform duration-300"
+          className={compact ? "h-3.5 w-3.5" : "h-4 w-4 transition-transform duration-300"}
           style={{ transform: isOpen ? "rotate(20deg)" : "rotate(0deg)" }}
         />
         {label}
       </button>
 
-      {/* Social platform buttons — burst out to the right */}
-      {PLATFORMS.map((platform, index) => {
+      {/* Compact mode: floating panel rendered via portal so it escapes
+          the parent card's stacking context and isn't painted under
+          sibling cards from the next grid row. */}
+      {compact && isOpen && panelAnchor && typeof document !== "undefined"
+        ? createPortal(
+            <div
+              ref={panelRef}
+              role="dialog"
+              aria-label="Share"
+              style={{
+                position: "fixed",
+                top: panelAnchor.top,
+                right: panelAnchor.right,
+                zIndex: 1000,
+              }}
+              className="flex items-center gap-1.5 rounded-full bg-white p-1.5 shadow-lg ring-1 ring-neutral-200"
+            >
+              {PLATFORMS.map((platform) => (
+                <button
+                  key={platform.id}
+                  type="button"
+                  aria-label={`Share on ${platform.label}`}
+                  onClick={() => handleSocialClick(platform)}
+                  style={{ backgroundColor: platform.bg }}
+                  className="inline-flex h-[30px] w-[30px] items-center justify-center rounded-full text-white shadow hover:brightness-110 active:scale-95"
+                >
+                  <platform.Icon />
+                </button>
+              ))}
+              <button
+                type="button"
+                aria-label="Copy link"
+                onClick={handleCopyClick}
+                className="inline-flex h-[30px] w-[30px] items-center justify-center rounded-full bg-neutral-700 text-white shadow hover:brightness-110 active:scale-95"
+              >
+                {status === "copied" ? (
+                  <Check className="h-4 w-4" />
+                ) : (
+                  <Link2 className="h-4 w-4" />
+                )}
+              </button>
+            </div>,
+            document.body
+          )
+        : null}
+
+      {/* Default mode: social platform buttons burst out to the right */}
+      {!compact && PLATFORMS.map((platform, index) => {
         const baseX = (mainButtonRef.current?.offsetWidth ?? 100) + 8;
         const offset = baseX + index * BUTTON_GAP;
         const delay = index * 50;
@@ -228,8 +339,8 @@ export default function ShareButton({
         );
       })}
 
-      {/* Copy link button */}
-      {(() => {
+      {/* Default mode: copy link button at end of burst */}
+      {!compact && (() => {
         const baseX = (mainButtonRef.current?.offsetWidth ?? 100) + 8;
         const offset = baseX + PLATFORMS.length * BUTTON_GAP;
         const delay = PLATFORMS.length * 50;


### PR DESCRIPTION
- Example grid card: drop the Save (favorite) action; Remix moves to the left, a compact ShareButton goes on the right. ShareButton gains a `compact` mode that renders a click-toggled social-icon panel (FB / X / LinkedIn / WhatsApp / Copy) below the button via React portal so the panel escapes the card's stacking context and isn't clipped or painted under sibling cards. Card overflow is loosened (rounded-corner clipping moved onto the image wrapper) so the share button itself isn't clipped.
- Carousel mobile flipping: react-zoom-pan-pinch was eating 1-finger drags as no-op panning at scale=1, making slide-swipe sluggish. Track scale locally and disable panning while not zoomed, so horizontal swipes flow through to the slide-track handler. Pinch zoom still works, panning re-enables once scale > 1.