### PR TITLE
Add 5 9-traits stereotype examples + watermark script --ids/--local f…

### DIFF
--- a/public/data/nano_inspiration.json
+++ b/public/data/nano_inspiration.json
@@ -42906,5 +42906,115 @@
       "cartoon",
       "evolution"
     ]
+  },
+  {
+    "id": "template-9-traits-info-grid-social-butterflies",
+    "template_id": "template-9-traits-info-grid",
+    "asset": {
+      "image_url": "/images/nano_insp/template-9-traits-info-grid-social-butterflies.jpg",
+      "preview_image_url": "/images/nano_insp_preview/template-9-traits-info-grid-social-butterflies-prev.jpg"
+    },
+    "params": {
+      "topic_title": "Social Butterflies"
+    },
+    "locales": {
+      "en": {
+        "title": "Social Butterflies"
+      }
+    },
+    "topics": [
+      "character",
+      "comparison",
+      "relationship",
+      "groups"
+    ]
+  },
+  {
+    "id": "template-9-traits-info-grid-small-talk-pros",
+    "template_id": "template-9-traits-info-grid",
+    "asset": {
+      "image_url": "/images/nano_insp/template-9-traits-info-grid-small-talk-pros.jpg",
+      "preview_image_url": "/images/nano_insp_preview/template-9-traits-info-grid-small-talk-pros-prev.jpg"
+    },
+    "params": {
+      "topic_title": "Small Talk Pros"
+    },
+    "locales": {
+      "en": {
+        "title": "Small Talk Pros"
+      }
+    },
+    "topics": [
+      "character",
+      "comparison",
+      "relationship",
+      "expressions"
+    ]
+  },
+  {
+    "id": "template-9-traits-info-grid-lone-wolf-thinkers",
+    "template_id": "template-9-traits-info-grid",
+    "asset": {
+      "image_url": "/images/nano_insp/template-9-traits-info-grid-lone-wolf-thinkers.jpg",
+      "preview_image_url": "/images/nano_insp_preview/template-9-traits-info-grid-lone-wolf-thinkers-prev.jpg"
+    },
+    "params": {
+      "topic_title": "Lone Wolf Thinkers"
+    },
+    "locales": {
+      "en": {
+        "title": "Lone Wolf Thinkers"
+      }
+    },
+    "topics": [
+      "character",
+      "comparison",
+      "relationship",
+      "personality"
+    ]
+  },
+  {
+    "id": "template-9-traits-info-grid-born-storytellers",
+    "template_id": "template-9-traits-info-grid",
+    "asset": {
+      "image_url": "/images/nano_insp/template-9-traits-info-grid-born-storytellers.jpg",
+      "preview_image_url": "/images/nano_insp_preview/template-9-traits-info-grid-born-storytellers-prev.jpg"
+    },
+    "params": {
+      "topic_title": "Born Storytellers"
+    },
+    "locales": {
+      "en": {
+        "title": "Born Storytellers"
+      }
+    },
+    "topics": [
+      "character",
+      "comparison",
+      "relationship",
+      "expressions"
+    ]
+  },
+  {
+    "id": "template-9-traits-info-grid-quiet-achievers",
+    "template_id": "template-9-traits-info-grid",
+    "asset": {
+      "image_url": "/images/nano_insp/template-9-traits-info-grid-quiet-achievers.jpg",
+      "preview_image_url": "/images/nano_insp_preview/template-9-traits-info-grid-quiet-achievers-prev.jpg"
+    },
+    "params": {
+      "topic_title": "Quiet Achievers"
+    },
+    "locales": {
+      "en": {
+        "title": "Quiet Achievers"
+      }
+    },
+    "topics": [
+      "character",
+      "comparison",
+      "relationship",
+      "personality"
+    ]
   }
 ]

--- a/scripts/watermark_template_images.cjs
+++ b/scripts/watermark_template_images.cjs
@@ -41,23 +41,38 @@ if (!['corner', 'tiled'].includes(mode)) {
   process.exit(1);
 }
 
+// Optional --ids=id1,id2,... filter to limit processing to specific
+// record ids (avoids re-watermarking already-stamped CDN copies).
+const idsArg = args.find(a => a.startsWith('--ids='));
+const idFilter = idsArg
+  ? new Set(idsArg.split('=')[1].split(',').map(s => s.trim()).filter(Boolean))
+  : null;
+
+// --local: read source images from public/images/ instead of downloading
+// from the CDN. Useful for fresh-generated images that haven't been
+// synced to GCS yet.
+const useLocalSource = args.includes('--local');
+
 const templateId = args.find(a => !a.startsWith('--'));
 if (!templateId) {
-  console.error('Usage: node scripts/watermark_template_images.cjs <template-id> [--mode=corner|tiled]');
+  console.error('Usage: node scripts/watermark_template_images.cjs <template-id> [--mode=corner|tiled] [--ids=id1,id2,...]');
   process.exit(1);
 }
 
 // ── Load inspiration JSON ─────────────────────────────────────────────────────
 
 const records = JSON.parse(fs.readFileSync(INSP_JSON, 'utf-8'));
-const images = records.filter(r => r.template_id === templateId);
+let images = records.filter(r => r.template_id === templateId);
+if (idFilter) {
+  images = images.filter(r => idFilter.has(r.id));
+}
 
 if (images.length === 0) {
-  console.error(`No images found for template_id "${templateId}"`);
+  console.error(`No images found for template_id "${templateId}"${idFilter ? ` (after --ids filter)` : ''}`);
   process.exit(1);
 }
 
-console.log(`Found ${images.length} images for "${templateId}"`);
+console.log(`Found ${images.length} images for "${templateId}"${idFilter ? ` (filtered)` : ''}`);
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
@@ -92,7 +107,16 @@ for (const record of images) {
     try {
       process.stdout.write(`  [${label}] ${filename} ... `);
 
-      downloadImage(fullUrl, srcFile);
+      if (useLocalSource) {
+        const localDir = isPreview ? LOCAL_PREVIEW_DIR : LOCAL_INSP_DIR;
+        const localSrc = path.join(localDir, filename);
+        if (!fs.existsSync(localSrc)) {
+          throw new Error(`local source missing: ${localSrc}`);
+        }
+        fs.copyFileSync(localSrc, srcFile);
+      } else {
+        downloadImage(fullUrl, srcFile);
+      }
 
       if (mode === 'tiled') {
         applyTiledWatermark(srcFile, destFile);


### PR DESCRIPTION
…lags

- Generate 5 new inspirations from scripts/configs/9_traits_stereotypes.json (Social Butterflies, Small Talk Pros, Lone Wolf Thinkers, Born Storytellers, Quiet Achievers) using Nano Banana Pro and apply tiled Curify watermarks. Uploaded to gs://curify-static/.
- watermark_template_images.cjs: add --ids=id1,id2,... to filter to a subset of records (avoids re-watermarking already-stamped CDN copies) and --local to read source images from public/images/ instead of downloading from the CDN (lets us watermark fresh-generated images before they're synced).