### PR TITLE
Add session-start page-view tracker for growth analytics

### DIFF
--- a/app/[locale]/(public)/layout.tsx
+++ b/app/[locale]/(public)/layout.tsx
@@ -16,6 +16,7 @@ import { Toaster } from "react-hot-toast";
 import GoogleAnalyticsInit from "../_components/GoogleAnalyticsInit";
 
 import GoogleAnalyticsTracker from "../_components/GoogleAnalyticsTracker";
+import SessionStartTracker from "../_components/SessionStartTracker";
 
 import { headers } from "next/headers";
 import { getCanonicalUrl, getLanguagesMap } from "@/lib/canonical";
@@ -69,6 +70,7 @@ export default async function PublicLocaleLayout({
       <GoogleAnalyticsInit />
 
         <GoogleAnalyticsTracker />
+        <SessionStartTracker />
         <Script src="https://cdn.jsdelivr.net/npm/mermaid@10/dist/mermaid.min.js" strategy="afterInteractive" />
         <Script id="init-mermaid" strategy="afterInteractive">
           {`

--- a/app/[locale]/_components/SessionStartTracker.tsx
+++ b/app/[locale]/_components/SessionStartTracker.tsx
@@ -1,0 +1,14 @@
+"use client";
+
+import { useSessionStartTracker } from "@/services/useTracking";
+
+/**
+ * Mount-only client component that fires a single page-view event the
+ * first time any page in a session is visited. Provides the bottom of
+ * the funnel (entry route, referrer, UTM) for sessions that would
+ * otherwise leave no trace if the user bounces without interacting.
+ */
+export default function SessionStartTracker() {
+  useSessionStartTracker();
+  return null;
+}

--- a/services/useTracking.ts
+++ b/services/useTracking.ts
@@ -16,7 +16,8 @@ export type ContentType =
   | "menu_link"
   | "breadcrumb"
   | "prev_next"
-  | "mbti_quiz";
+  | "mbti_quiz"
+  | "page";
 
 export type ActionType =
   | "view"
@@ -282,6 +283,29 @@ export function useSaveTracking(
   return useCallback(() => {
     trackAction({ contentId, contentType, viewMode }, "favorite");
   }, [contentId, contentType, viewMode, trackAction]);
+}
+
+// Once-per-session "page view" event so growth analytics can see the
+// entry route + referrer + UTM for sessions that bounce without
+// triggering any explicit interaction. Mounted in the public layout
+// via SessionStartTracker. Bots are filtered out so they don't pollute
+// real-user funnels.
+const SESSION_VIEW_FLAG = "_curify_session_view_fired";
+const BOT_UA_RE_TRACK = /bot|spider|crawl|slurp|screenshot/i;
+
+export function useSessionStartTracker() {
+  const { track } = useTracking();
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    if (BOT_UA_RE_TRACK.test(navigator.userAgent || "")) return;
+    if (sessionStorage.getItem(SESSION_VIEW_FLAG)) return;
+    sessionStorage.setItem(SESSION_VIEW_FLAG, "1");
+    track({
+      contentId: window.location.pathname,
+      contentType: "page",
+      actionType: "view",
+    });
+  }, [track]);
 }
 
 export function useVideoTracking(


### PR DESCRIPTION
Fires a single 'view' interaction with content_type=page once per sessionStorage-bounded session, on the first public-page mount. Captures entry route + referrer + UTM (already in buildPayload) so single-page bounce sessions stop being invisible in interaction-only analytics.

Bot UAs are filtered to keep real-user funnels clean, matching the GoogleAnalyticsInit behavior.