### PR TITLE
rank_score: switch engagement window to 14d, mult 0.15, cap 35

### DIFF
--- a/public/data/nano_templates.json
+++ b/public/data/nano_templates.json
@@ -39,7 +39,7 @@
       "learning",
       "science"
     ],
-    "rank_score": 80.4,
+    "rank_score": 109.1,
     "batch": true,
     "base_rank_score": 80,
     "allow_generation": true,
@@ -90,7 +90,7 @@
       "science",
       "isometric"
     ],
-    "rank_score": 84,
+    "rank_score": 84.65,
     "base_rank_score": 80,
     "allow_generation": true,
     "use_cases": [
@@ -158,7 +158,7 @@
       "kawaii",
       "itinerary"
     ],
-    "rank_score": 135.8,
+    "rank_score": 136.95,
     "batch": true,
     "base_rank_score": 120,
     "allow_generation": true,
@@ -202,7 +202,7 @@
       "learning",
       "architecture"
     ],
-    "rank_score": 80,
+    "rank_score": 89.6,
     "base_rank_score": 80,
     "allow_generation": true,
     "creation_date": "2026-04-03"
@@ -246,7 +246,7 @@
       "science",
       "animal"
     ],
-    "rank_score": 80,
+    "rank_score": 83.9,
     "base_rank_score": 80,
     "allow_generation": true,
     "creation_date": "2026-04-03"
@@ -307,7 +307,7 @@
       "character",
       "film"
     ],
-    "rank_score": 85.8,
+    "rank_score": 86.45,
     "base_rank_score": 80,
     "allow_generation": true,
     "intro_video_url": "/video/template_intro/template-character.mp4",
@@ -351,7 +351,7 @@
       "lifestyle",
       "food"
     ],
-    "rank_score": 81.6,
+    "rank_score": 81.35,
     "base_rank_score": 80,
     "allow_generation": true,
     "creation_date": "2026-04-04"
@@ -419,7 +419,7 @@
     "topics": [
       "character"
     ],
-    "rank_score": 83,
+    "rank_score": 83.6,
     "base_rank_score": 80,
     "allow_generation": true,
     "intro_video_url": "/video/template_intro/template-character-analysis.mp4",
@@ -465,7 +465,7 @@
       "cartoon",
       "isometric"
     ],
-    "rank_score": 80.2,
+    "rank_score": 81.8,
     "base_rank_score": 80,
     "allow_generation": true,
     "creation_date": "2026-04-04"
@@ -508,7 +508,7 @@
       "learning",
       "cartoon"
     ],
-    "rank_score": 80.4,
+    "rank_score": 80.3,
     "use_cases": [
       "for-marketers"
     ],
@@ -588,7 +588,7 @@
       "learning",
       "trending"
     ],
-    "rank_score": 60.4,
+    "rank_score": 62.1,
     "use_cases": [
       "for-marketers"
     ],
@@ -637,7 +637,7 @@
       "culture",
       "travel"
     ],
-    "rank_score": 73.6,
+    "rank_score": 74.95,
     "base_rank_score": 70,
     "allow_generation": true,
     "intro_video_url": "/video/template_intro/template-intangible-heritage.mp4",
@@ -681,7 +681,7 @@
       "science",
       "cartoon"
     ],
-    "rank_score": 82.8,
+    "rank_score": 107.15,
     "use_cases": [
       "for-marketers",
       "for-creators",
@@ -732,7 +732,7 @@
       "culture",
       "travel"
     ],
-    "rank_score": 94.2,
+    "rank_score": 93.05,
     "batch": true,
     "base_rank_score": 80,
     "allow_generation": true,
@@ -777,7 +777,7 @@
     "topics": [
       "learning"
     ],
-    "rank_score": 81.2,
+    "rank_score": 85.4,
     "use_cases": [
       "for-marketers",
       "for-creators"
@@ -854,7 +854,7 @@
       "language",
       "vocabulary"
     ],
-    "rank_score": 84.6,
+    "rank_score": 96.5,
     "use_cases": [
       "for-parents",
       "for-esl-learners"
@@ -916,7 +916,7 @@
       "culture",
       "travel"
     ],
-    "rank_score": 2.4000000000000004,
+    "rank_score": 2.3499999999999996,
     "base_rank_score": 1,
     "allow_generation": true,
     "intro_video_url": "/video/template_intro/template-cultural-relic-retro-infographic.mp4",
@@ -1009,7 +1009,7 @@
       "science",
       "animal"
     ],
-    "rank_score": 1,
+    "rank_score": 2.65,
     "base_rank_score": 1,
     "intro_video_url": "/video/template_intro/template-dog-breed-retro-infographic.mp4",
     "creation_date": "2026-04-07"
@@ -1057,7 +1057,7 @@
       "lifestyle",
       "food"
     ],
-    "rank_score": 89.2,
+    "rank_score": 88.7,
     "base_rank_score": 80,
     "allow_generation": true,
     "intro_video_url": "/video/template_intro/template-food.mp4",
@@ -1144,7 +1144,7 @@
       "culture",
       "travel"
     ],
-    "rank_score": 83.8,
+    "rank_score": 83.45,
     "base_rank_score": 80,
     "allow_generation": true,
     "intro_video_url": "/video/template_intro/template-solar-term.mp4",
@@ -1183,7 +1183,7 @@
       "lifestyle",
       "food"
     ],
-    "rank_score": 81.6,
+    "rank_score": 84.5,
     "base_rank_score": 80,
     "allow_generation": true,
     "use_cases": [
@@ -1246,7 +1246,7 @@
       "history",
       "ink"
     ],
-    "rank_score": 80.6,
+    "rank_score": 82.25,
     "base_rank_score": 80,
     "allow_generation": true,
     "intro_video_url": "/video/template_intro/template-what-if-history.mp4",
@@ -1367,7 +1367,7 @@
       "groups",
       "animal"
     ],
-    "rank_score": 80,
+    "rank_score": 81.2,
     "base_rank_score": 80,
     "allow_generation": true,
     "intro_video_url": "/video/template_intro/template-mbti-animal.mp4",
@@ -1446,7 +1446,7 @@
       "comparison",
       "ink"
     ],
-    "rank_score": 80.2,
+    "rank_score": 80.3,
     "use_cases": [
       "for-creators"
     ],
@@ -1499,7 +1499,7 @@
       "mockups",
       "product"
     ],
-    "rank_score": 80.4,
+    "rank_score": 81.35,
     "base_rank_score": 80,
     "requires_image_upload": true,
     "allow_generation": true,
@@ -1524,7 +1524,7 @@
       "fashion",
       "design"
     ],
-    "rank_score": 82.4,
+    "rank_score": 84.2,
     "base_rank_score": 80,
     "requires_image_upload": true,
     "intro_video_url": "/video/template_intro/template-portrait-retouching-blueprint.mp4",
@@ -1618,7 +1618,7 @@
       "comparison",
       "cartoon"
     ],
-    "rank_score": 80,
+    "rank_score": 82.1,
     "base_rank_score": 80,
     "intro_video_url": "/video/template_intro/template-mbti-contrast.mp4",
     "creation_date": "2026-04-09"
@@ -1663,7 +1663,7 @@
       "culture",
       "travel"
     ],
-    "rank_score": 85.6,
+    "rank_score": 84.2,
     "base_rank_score": 80,
     "allow_generation": true,
     "intro_video_url": "/video/template_intro/template-guofeng-scroll.mp4",
@@ -1714,7 +1714,7 @@
       "science",
       "animal"
     ],
-    "rank_score": 82.8,
+    "rank_score": 84.95,
     "base_rank_score": 80,
     "allow_generation": true,
     "use_cases": [
@@ -1767,7 +1767,7 @@
       "travel",
       "city"
     ],
-    "rank_score": 80,
+    "rank_score": 86.75,
     "base_rank_score": 80,
     "allow_generation": true,
     "intro_video_url": "/video/template_intro/template-city-miniature.mp4",
@@ -1817,7 +1817,7 @@
       "learning",
       "trending"
     ],
-    "rank_score": 74,
+    "rank_score": 74.65,
     "use_cases": [
       "for-marketers",
       "for-creators"
@@ -1898,7 +1898,7 @@
       "design",
       "digital-canvas"
     ],
-    "rank_score": 80,
+    "rank_score": 81.2,
     "base_rank_score": 80,
     "intro_video_url": "/video/template_intro/template-constellation-steampunk.mp4",
     "creation_date": "2026-04-10"
@@ -1972,7 +1972,7 @@
       "groups",
       "cartoon"
     ],
-    "rank_score": 84.2,
+    "rank_score": 85.85,
     "use_cases": [
       "for-marketers",
       "for-creators"
@@ -2009,7 +2009,7 @@
       "film",
       "isometric"
     ],
-    "rank_score": 80.4,
+    "rank_score": 98.6,
     "base_rank_score": 80,
     "allow_generation": true,
     "intro_video_url": "/video/template_intro/template-mbti-marvel.mp4",
@@ -2041,7 +2041,7 @@
       "mbti",
       "sports"
     ],
-    "rank_score": 100.4,
+    "rank_score": 120.1,
     "base_rank_score": 100,
     "allow_generation": true,
     "intro_video_url": "/video/template_intro/template-mbti-nba.mp4",
@@ -2074,7 +2074,7 @@
       "ai",
       "isometric"
     ],
-    "rank_score": 80,
+    "rank_score": 81.8,
     "use_cases": [
       "for-marketers",
       "for-creators"
@@ -2111,7 +2111,7 @@
       "film",
       "isometric"
     ],
-    "rank_score": 71,
+    "rank_score": 74.65,
     "base_rank_score": 70,
     "allow_generation": true,
     "intro_video_url": "/video/template_intro/template-mbti-breakingbad.mp4",
@@ -2156,7 +2156,7 @@
       "sports",
       "comparison"
     ],
-    "rank_score": 1,
+    "rank_score": 2.5,
     "base_rank_score": 1,
     "allow_generation": true,
     "intro_video_url": "/video/template_intro/template-sports-battle.mp4",
@@ -2190,7 +2190,7 @@
       "film",
       "anime"
     ],
-    "rank_score": 10,
+    "rank_score": 11.15,
     "use_cases": [
       "for-marketers",
       "for-creators"
@@ -2226,7 +2226,7 @@
       "mbti",
       "film"
     ],
-    "rank_score": 70.8,
+    "rank_score": 71.05,
     "base_rank_score": 70,
     "allow_generation": true,
     "intro_video_url": "/video/template_intro/template-mbti-yellowstone.mp4",
@@ -2259,7 +2259,7 @@
       "film",
       "anime"
     ],
-    "rank_score": 101.4,
+    "rank_score": 108.7,
     "use_cases": [
       "for-marketers",
       "for-creators"
@@ -2336,7 +2336,7 @@
       "kawaii"
     ],
     "batch": true,
-    "rank_score": 81.2,
+    "rank_score": 103.85,
     "use_cases": [
       "for-parents",
       "for-esl-learners"
@@ -2413,7 +2413,7 @@
       "learning",
       "trending"
     ],
-    "rank_score": 70,
+    "rank_score": 72.1,
     "use_cases": [
       "for-marketers",
       "for-creators"
@@ -2488,7 +2488,7 @@
       "kawaii"
     ],
     "batch": true,
-    "rank_score": 80,
+    "rank_score": 82.1,
     "use_cases": [
       "for-parents",
       "for-esl-learners"
@@ -2561,7 +2561,7 @@
       "kawaii"
     ],
     "batch": true,
-    "rank_score": 80,
+    "rank_score": 84.65,
     "use_cases": [
       "for-parents",
       "for-esl-learners"
@@ -2636,7 +2636,7 @@
       "dialogue",
       "kawaii"
     ],
-    "rank_score": 80.2,
+    "rank_score": 82.55,
     "use_cases": [
       "for-parents",
       "for-esl-learners"
@@ -2672,7 +2672,7 @@
       "film",
       "kawaii"
     ],
-    "rank_score": 80,
+    "rank_score": 80.3,
     "base_rank_score": 80,
     "allow_generation": true,
     "intro_video_url": "/video/template_intro/template-movie-poster.mp4",
@@ -2715,7 +2715,7 @@
       "kawaii",
       "itinerary"
     ],
-    "rank_score": 94.2,
+    "rank_score": 95.75,
     "base_rank_score": 80,
     "allow_generation": true,
     "intro_video_url": "/video/template_intro/template-series-travel.mp4",
@@ -2835,7 +2835,7 @@
       "fitness",
       "kawaii"
     ],
-    "rank_score": 1,
+    "rank_score": 2.5,
     "base_rank_score": 1,
     "creation_date": "2026-04-15"
   },
@@ -2890,7 +2890,7 @@
       "learning",
       "kawaii"
     ],
-    "rank_score": 2,
+    "rank_score": 2.75,
     "use_cases": [
       "for-parents"
     ],
@@ -2920,7 +2920,7 @@
       }
     },
     "og_image": "/images/nano_insp_preview/template-detailed-vocab-flashcard-dog-prev.jpg",
-    "rank_score": 81.8,
+    "rank_score": 84.05,
     "topics": [
       "language",
       "vocabulary"
@@ -3013,7 +3013,7 @@
       }
     },
     "og_image": "/images/nano_insp_preview/template-custom-character-card--prev.jpg",
-    "rank_score": 2,
+    "rank_score": 4.1,
     "topics": [
       "character",
       "mbti"
@@ -3046,7 +3046,7 @@
       }
     },
     "og_image": "/images/nano_insp_preview/template-detective-conan-conan-edogawa-prev.jpg",
-    "rank_score": 80,
+    "rank_score": 80.9,
     "topics": [
       "character",
       "mbti",
@@ -3081,7 +3081,7 @@
       }
     },
     "og_image": "/images/nano_insp_preview/template-children-english-vocab-spelling-weather-prev.jpg",
-    "rank_score": 80,
+    "rank_score": 80.15,
     "topics": [
       "language",
       "vocabulary",
@@ -3117,7 +3117,7 @@
       }
     },
     "og_image": "/images/nano_insp_preview/template-daily-essentials-learning-card-school-supplies-prev.jpg",
-    "rank_score": 80,
+    "rank_score": 80.3,
     "topics": [
       "language",
       "vocabulary",
@@ -3185,7 +3185,7 @@
       }
     },
     "og_image": "/images/nano_insp_preview/template-theme-overview-poster-tcm-clearing-heat-herbs-prev.jpg",
-    "rank_score": 102.2,
+    "rank_score": 131.2,
     "topics": [
       "design",
       "posters",
@@ -3218,7 +3218,7 @@
       }
     },
     "og_image": "/images/nano_insp_preview/template-cuisine-food-vocab-poster-beijing-prev.jpg",
-    "rank_score": 101.4,
+    "rank_score": 120.55,
     "topics": [
       "language",
       "food",
@@ -3254,7 +3254,7 @@
       }
     },
     "og_image": "/images/nano_insp_preview/template-industrial-design-concept-sketch-humanoid-robot-prev.jpg",
-    "rank_score": 50,
+    "rank_score": 63.5,
     "topics": [
       "design",
       "mockups",
@@ -3287,7 +3287,7 @@
       }
     },
     "og_image": "/images/nano_insp_preview/template-varieties-food-poster-salad-prev.jpg",
-    "rank_score": 100,
+    "rank_score": 110.35,
     "topics": [
       "lifestyle",
       "food",
@@ -3322,7 +3322,7 @@
       }
     },
     "og_image": "/images/nano_insp_preview/template-warmup-routine-gym-prev.jpg",
-    "rank_score": 90,
+    "rank_score": 93.45,
     "base_rank_score": 90,
     "topics": [
       "lifestyle",
@@ -3360,7 +3360,7 @@
       }
     },
     "og_image": "/images/nano_insp_preview/template-group-vocab-category-sports-prev.jpg",
-    "rank_score": 90.4,
+    "rank_score": 97.5,
     "base_rank_score": 90,
     "topics": [
       "language",
@@ -3395,7 +3395,7 @@
       }
     },
     "og_image": "/images/nano_insp_preview/template-city-mbti-beijing-prev.jpg",
-    "rank_score": 70.2,
+    "rank_score": 70.15,
     "base_rank_score": 70,
     "topics": [
       "character",
@@ -3428,7 +3428,7 @@
       }
     },
     "og_image": "/images/nano_insp_preview/template-clothing-evolution-poster--prev.jpg",
-    "rank_score": 92.2,
+    "rank_score": 106.2,
     "base_rank_score": 90,
     "topics": [
       "design",
@@ -3475,7 +3475,7 @@
       }
     },
     "og_image": "/images/nano_insp_preview/template-soft-decoration-design-guide-poster-en-preview.jpg",
-    "rank_score": 92.8,
+    "rank_score": 94.05,
     "base_rank_score": 90,
     "topics": [
       "lifestyle",
@@ -3508,7 +3508,7 @@
       }
     },
     "og_image": "/images/nano_insp_preview/template-home-organization-before-after-living-room-shelf-prev.jpg",
-    "rank_score": 90,
+    "rank_score": 91.35,
     "base_rank_score": 90,
     "topics": [
       "design",
@@ -3542,7 +3542,7 @@
       }
     },
     "og_image": "/images/nano_insp_preview/template-stick-figure-vocab-body-movement-verbs-set1-prev.jpg",
-    "rank_score": 70,
+    "rank_score": 70.15,
     "base_rank_score": 70,
     "topics": [
       "language",
@@ -3620,7 +3620,7 @@
       "learning"
     ],
     "base_rank_score": 70,
-    "rank_score": 70,
+    "rank_score": 71.95,
     "allow_generation": true,
     "intro_video_url": "/video/template_intro/template-tool-ai-category.mp4",
     "creation_date": "2026-04-20"
@@ -3654,7 +3654,7 @@
       "travel"
     ],
     "base_rank_score": 70,
-    "rank_score": 74,
+    "rank_score": 73.3,
     "allow_generation": true,
     "intro_video_url": "/video/template_intro/template-chinese-classic-character-mbti.mp4",
     "creation_date": "2026-04-20"
@@ -3693,7 +3693,7 @@
       "kawaii"
     ],
     "base_rank_score": 90,
-    "rank_score": 90.6,
+    "rank_score": 98.85,
     "allow_generation": true,
     "intro_video_url": "/video/template_intro/template-friends-character-mbti.mp4",
     "creation_date": "2026-04-20"
@@ -3724,7 +3724,7 @@
       "ink"
     ],
     "base_rank_score": 90,
-    "rank_score": 91.6,
+    "rank_score": 93.15,
     "allow_generation": true,
     "intro_video_url": "/video/template_intro/template-poetry-ink-wash-illustration.mp4",
     "creation_date": "2026-04-20"
@@ -3757,7 +3757,7 @@
       "kawaii"
     ],
     "base_rank_score": 90,
-    "rank_score": 90.6,
+    "rank_score": 93.45,
     "allow_generation": true,
     "intro_video_url": "/video/template_intro/template-financial-habit-infographic-poster.mp4",
     "creation_date": "2026-04-21"
@@ -3791,7 +3791,7 @@
       "photorealistic"
     ],
     "base_rank_score": 90,
-    "rank_score": 90,
+    "rank_score": 94.05,
     "allow_generation": true,
     "intro_video_url": "/video/template_intro/template-bilingual-object-structure-labeling.mp4",
     "creation_date": "2026-04-21"
@@ -3825,7 +3825,7 @@
       "interior",
       "photorealistic"
     ],
-    "rank_score": 94.2,
+    "rank_score": 95.85,
     "base_rank_score": 90,
     "requires_image_upload": true,
     "allow_generation": true,
@@ -3857,7 +3857,7 @@
       "lifestyle",
       "fashion"
     ],
-    "rank_score": 90,
+    "rank_score": 96.75,
     "base_rank_score": 90,
     "requires_image_upload": true,
     "allow_generation": true,
@@ -3888,7 +3888,7 @@
       }
     },
     "og_image": "/images/nano_insp_preview/template-pain-relief-infographic-back-pain-yoga-prev.jpg",
-    "rank_score": 80,
+    "rank_score": 83,
     "base_rank_score": 80,
     "topics": [
       "lifestyle",
@@ -3921,7 +3921,7 @@
       }
     },
     "og_image": "/images/nano_insp_preview/template-equipment-muscle-guide-leg-press-lat-pulldown-chest-press-cable-row-prev.jpg",
-    "rank_score": 90,
+    "rank_score": 91.5,
     "base_rank_score": 90,
     "topics": [
       "lifestyle",
@@ -3955,7 +3955,7 @@
       }
     },
     "og_image": "/images/nano_insp_preview/template-kids-vocabulary-poster-vegetables-prev.jpg",
-    "rank_score": 80.8,
+    "rank_score": 81.8,
     "base_rank_score": 80,
     "topics": [
       "language",
@@ -3990,7 +3990,7 @@
       }
     },
     "og_image": "/images/nano_insp_preview/template-beauty-step-by-step-guide-hairstyle-tutorial-prev.jpg",
-    "rank_score": 80,
+    "rank_score": 83.9,
     "base_rank_score": 80,
     "topics": [
       "lifestyle",
@@ -4029,7 +4029,7 @@
       "architecture",
       "photorealistic"
     ],
-    "rank_score": 93.8,
+    "rank_score": 97.2,
     "base_rank_score": 90,
     "allow_generation": true,
     "intro_video_url": "/video/template_intro/template-3d-region-landmark-map.mp4",
@@ -4061,7 +4061,7 @@
       "travel",
       "cartoon"
     ],
-    "rank_score": 90.2,
+    "rank_score": 92.55,
     "base_rank_score": 90,
     "allow_generation": true,
     "intro_video_url": "/video/template_intro/template-whimsical-travel-map.mp4",
@@ -4093,7 +4093,7 @@
       "character",
       "film"
     ],
-    "rank_score": 92.4,
+    "rank_score": 95.85,
     "base_rank_score": 90,
     "allow_generation": true,
     "intro_video_url": "/video/template_intro/template-pop-culture-matching-chart.mp4",
@@ -4129,7 +4129,7 @@
       "fitness",
       "guides"
     ],
-    "rank_score": 70,
+    "rank_score": 70.3,
     "base_rank_score": 70,
     "allow_generation": true,
     "intro_video_url": "/video/template_intro/template-training-muscle-equipment.mp4",
@@ -4163,7 +4163,7 @@
       "lifestyle",
       "fitness"
     ],
-    "rank_score": 70,
+    "rank_score": 75.7,
     "base_rank_score": 70,
     "allow_generation": true,
     "use_cases": [
@@ -4209,7 +4209,7 @@
       "mbti",
       "groups"
     ],
-    "rank_score": 70.4,
+    "rank_score": 70.6,
     "base_rank_score": 70,
     "allow_generation": true,
     "intro_video_url": "/video/template_intro/template-personality-choice-quiz-card.mp4",
@@ -4242,7 +4242,7 @@
       "lifestyle",
       "guides"
     ],
-    "rank_score": 70.2,
+    "rank_score": 80.8,
     "base_rank_score": 70,
     "allow_generation": true,
     "intro_video_url": "/video/template_intro/template-lifestyle-info-card.mp4",
@@ -4276,7 +4276,7 @@
       "learning",
       "history"
     ],
-    "rank_score": 70.2,
+    "rank_score": 73,
     "base_rank_score": 70,
     "allow_generation": true,
     "intro_video_url": "/video/template_intro/template-historical-event-map-illustration.mp4",
@@ -4321,7 +4321,7 @@
     "topics": [
       "learning"
     ],
-    "rank_score": 72.8,
+    "rank_score": 77.05,
     "base_rank_score": 70,
     "allow_generation": true,
     "intro_video_url": "/video/template_intro/template-national-theme-map-infographic.mp4",
@@ -4357,7 +4357,7 @@
       "cartoon",
       "groups"
     ],
-    "rank_score": 70,
+    "rank_score": 71.65,
     "allow_generation": true,
     "base_rank_score": 70,
     "intro_video_url": "/video/template_intro/template-fandom-character-grid-poster.mp4",
@@ -4423,7 +4423,7 @@
       "kawaii",
       "portrait"
     ],
-    "rank_score": 70,
+    "rank_score": 71.05,
     "base_rank_score": 70,
     "intro_video_url": "/video/template_intro/template-cartoon-character-profile-card-kawaii-style.mp4",
     "creation_date": "2026-04-25"
@@ -4456,7 +4456,7 @@
       "vocabulary",
       "kawaii"
     ],
-    "rank_score": 70,
+    "rank_score": 71.65,
     "allow_generation": true,
     "use_cases": [
       "for-parents"
@@ -4493,7 +4493,7 @@
       "learning",
       "reading"
     ],
-    "rank_score": 90.6,
+    "rank_score": 96.3,
     "base_rank_score": 90,
     "allow_generation": true,
     "intro_video_url": "/video/template_intro/template-figure-principles-infographic.mp4",
@@ -4527,7 +4527,7 @@
       "design",
       "posters"
     ],
-    "rank_score": 90.4,
+    "rank_score": 90.75,
     "base_rank_score": 90,
     "intro_video_url": "/video/template_intro/template-book-recommendation-grid-poster.mp4",
     "creation_date": "2026-04-26",
@@ -4606,7 +4606,7 @@
       "vocabulary",
       "kawaii"
     ],
-    "rank_score": 91.8,
+    "rank_score": 113,
     "base_rank_score": 80,
     "intro_video_url": "/video/template_intro/template-language-word-comparison-educational-poster.mp4",
     "creation_date": "2026-04-26"
@@ -4637,7 +4637,7 @@
     "topics": [
       "travel"
     ],
-    "rank_score": 81.6,
+    "rank_score": 81.9,
     "base_rank_score": 80,
     "intro_video_url": "/video/template_intro/template-world-travel-map-illustration.mp4",
     "creation_date": "2026-04-27",
@@ -4668,7 +4668,7 @@
       "culture",
       "travel"
     ],
-    "rank_score": 91.4,
+    "rank_score": 95.35,
     "base_rank_score": 90,
     "intro_video_url": "/video/template_intro/template-east-asian-culture-comparison-infographic.mp4",
     "creation_date": "2026-04-27",
@@ -4701,7 +4701,7 @@
       "design",
       "watercolor"
     ],
-    "rank_score": 91.4,
+    "rank_score": 97,
     "base_rank_score": 90,
     "use_cases": [
       "for-parents"
@@ -4740,7 +4740,7 @@
       "fitness",
       "monochrome"
     ],
-    "rank_score": 91,
+    "rank_score": 91.9,
     "base_rank_score": 90,
     "allow_generation": true,
     "intro_video_url": "/video/template_intro/template-personal-journey-wolf-path-illustration.mp4",
@@ -4803,7 +4803,7 @@
       "language",
       "watercolor"
     ],
-    "rank_score": 83,
+    "rank_score": 84.8,
     "base_rank_score": 80,
     "allow_generation": true,
     "intro_video_url": "/video/template_intro/template-multilingual-vocabulary-poster-watercolor.mp4",
@@ -4836,7 +4836,7 @@
       "design",
       "guides"
     ],
-    "rank_score": 93,
+    "rank_score": 95.25,
     "base_rank_score": 90,
     "allow_generation": true,
     "intro_video_url": "/video/template_intro/template-premium-recipe-card-infographic.mp4",
@@ -4870,7 +4870,7 @@
       "mbti",
       "culture"
     ],
-    "rank_score": 83,
+    "rank_score": 83.6,
     "base_rank_score": 80,
     "allow_generation": true,
     "creation_date": "2026-04-28"
@@ -4900,7 +4900,7 @@
       "posters",
       "reading"
     ],
-    "rank_score": 93.4,
+    "rank_score": 96.45,
     "base_rank_score": 90,
     "allow_generation": true,
     "intro_video_url": "/video/template_intro/template-quote-poster-generator.mp4",
@@ -4931,7 +4931,7 @@
       "learning",
       "science"
     ],
-    "rank_score": 96.6,
+    "rank_score": 106.15,
     "base_rank_score": 90,
     "allow_generation": true,
     "creation_date": "2026-04-29"
@@ -4964,7 +4964,7 @@
       "travel",
       "history"
     ],
-    "rank_score": 95.6,
+    "rank_score": 103.9,
     "base_rank_score": 90,
     "allow_generation": true,
     "intro_video_url": "/video/template_intro/template-world-landmark-vintage-info-poster.mp4",
@@ -4998,7 +4998,7 @@
       "mbti",
       "culture"
     ],
-    "rank_score": 84,
+    "rank_score": 84.15,
     "base_rank_score": 80,
     "allow_generation": true,
     "intro_video_url": "/video/template_intro/template-princess-pearl-mbti-character-card.mp4",
@@ -5027,7 +5027,7 @@
       }
     },
     "og_image": "/images/nano_insp_preview/template-CVC-english-word-coloring-flower-card-ap-prev.jpg",
-    "rank_score": 84,
+    "rank_score": 87.15,
     "base_rank_score": 80,
     "allow_generation": true,
     "topics": [
@@ -5063,7 +5063,7 @@
       }
     },
     "og_image": "/images/nano_insp_preview/template-weird-cold-knowledge-popular-science-card-tardigrades-prev.jpg",
-    "rank_score": 86.8,
+    "rank_score": 90.35,
     "base_rank_score": 80,
     "allow_generation": true,
     "topics": [
@@ -5096,7 +5096,7 @@
       }
     },
     "og_image": "/images/nano_insp_preview/template-country-top10-travel-destinations-france-prev.jpg",
-    "rank_score": 86,
+    "rank_score": 92.3,
     "base_rank_score": 80,
     "allow_generation": true,
     "topics": [
@@ -5130,7 +5130,7 @@
       }
     },
     "og_image": "/images/nano_insp_preview/template-book-minimalist-gardening-beginners-prev.jpg",
-    "rank_score": 97,
+    "rank_score": 99.45,
     "base_rank_score": 90,
     "allow_generation": true,
     "topics": [
@@ -5170,7 +5170,7 @@
       "language"
     ],
     "base_rank_score": 90,
-    "rank_score": 96.8,
+    "rank_score": 102.45,
     "intro_video_url": "/video/template_intro/template-verb-action-learning-cards.mp4",
     "creation_date": "2026-04-30",
     "allow_generation": true
@@ -5216,7 +5216,7 @@
       "guides"
     ],
     "base_rank_score": 90,
-    "rank_score": 97,
+    "rank_score": 99.55,
     "creation_date": "2026-05-01"
   },
   {
@@ -5249,7 +5249,7 @@
       "relationship"
     ],
     "base_rank_score": 90,
-    "rank_score": 100,
+    "rank_score": 101.5,
     "intro_video_url": "/video/template_intro/template-9-traits-info-grid.mp4",
     "creation_date": "2026-05-01",
     "allow_generation": true
@@ -5285,7 +5285,7 @@
       "expressions"
     ],
     "base_rank_score": 90,
-    "rank_score": 97,
+    "rank_score": 101.35,
     "allow_generation": true,
     "intro_video_url": "/video/template_intro/template-english-phrasal-verb.mp4",
     "creation_date": "2026-05-01"
@@ -5305,7 +5305,7 @@
       "portrait"
     ],
     "base_rank_score": 90,
-    "rank_score": 97.4,
+    "rank_score": 101.2,
     "creation_date": "2026-05-01"
   },
   {
@@ -5341,7 +5341,7 @@
       "posters"
     ],
     "base_rank_score": 90,
-    "rank_score": 99.6,
+    "rank_score": 107.1,
     "allow_generation": true,
     "intro_video_url": "/video/template_intro/template-country-souvenirs-watercolor.mp4",
     "creation_date": "2026-05-02"
@@ -5377,7 +5377,7 @@
       "animals"
     ],
     "base_rank_score": 90,
-    "rank_score": 99,
+    "rank_score": 100.95,
     "intro_video_url": "/video/template_intro/template-pet-safe-human-food-infographic.mp4",
     "creation_date": "2026-05-02",
     "allow_generation": true
@@ -5414,7 +5414,7 @@
       "language-english"
     ],
     "base_rank_score": 90,
-    "rank_score": 99.6,
+    "rank_score": 103.35,
     "intro_video_url": "/video/template_intro/template-phonics-consonant-blend.mp4",
     "creation_date": "2026-05-02",
     "allow_generation": true
@@ -5450,7 +5450,7 @@
       "posters"
     ],
     "base_rank_score": 90,
-    "rank_score": 99.8,
+    "rank_score": 100.2,
     "intro_video_url": "/video/template_intro/template-media-theme-wallpaper-poster.mp4",
     "creation_date": "2026-05-02",
     "allow_generation": true
@@ -5501,7 +5501,7 @@
       "posters"
     ],
     "base_rank_score": 80,
-    "rank_score": 90.2,
+    "rank_score": 93,
     "intro_video_url": "/video/template_intro/template-chinese-character-learning-poster.mp4",
     "creation_date": "2026-05-03"
   },
@@ -5551,7 +5551,7 @@
       "comparison"
     ],
     "base_rank_score": 80,
-    "rank_score": 90.2,
+    "rank_score": 92.7,
     "intro_video_url": "/video/template_intro/template-mbti-relationship-infographic.mp4",
     "creation_date": "2026-05-03"
   },
@@ -5582,7 +5582,7 @@
       "posters"
     ],
     "base_rank_score": 90,
-    "rank_score": 107.2,
+    "rank_score": 135,
     "allow_generation": true,
     "intro_video_url": "/video/template_intro/template-chinese-verb-opposite-infographic.mp4",
     "creation_date": "2026-05-03"
@@ -5602,7 +5602,7 @@
       "posters"
     ],
     "base_rank_score": 90,
-    "rank_score": 100,
+    "rank_score": 102.4,
     "intro_video_url": "/video/template_intro/template-ai-outfit-try-on-poster.mp4",
     "creation_date": "2026-05-03"
   },
@@ -5646,7 +5646,7 @@
       "posters"
     ],
     "base_rank_score": 90,
-    "rank_score": 101.6,
+    "rank_score": 101.45,
     "intro_video_url": "/video/template_intro/template-lifestyle-watercolor-infographic.mp4",
     "creation_date": "2026-05-04"
   },
@@ -5681,7 +5681,7 @@
       "posters"
     ],
     "base_rank_score": 90,
-    "rank_score": 101.4,
+    "rank_score": 102.8,
     "intro_video_url": "/video/template_intro/template-gardening-how-to-infographic.mp4",
     "creation_date": "2026-05-04",
     "allow_generation": true
@@ -5717,7 +5717,7 @@
       "fashion"
     ],
     "base_rank_score": 90,
-    "rank_score": 117.4,
+    "rank_score": 115.25,
     "intro_video_url": "/video/template_intro/template-ethnic-costume-deconstruction-board.mp4",
     "creation_date": "2026-05-04",
     "allow_generation": true
@@ -5759,7 +5759,7 @@
       "comparison"
     ],
     "base_rank_score": 80,
-    "rank_score": 91,
+    "rank_score": 91.15,
     "intro_video_url": "/video/template_intro/template-animation-studio-comparison-infographic.mp4",
     "creation_date": "2026-05-04"
   },
@@ -5812,7 +5812,7 @@
       "guides"
     ],
     "base_rank_score": 80,
-    "rank_score": 93.2,
+    "rank_score": 93.15,
     "intro_video_url": "/video/template_intro/template-travel-packing-guide-infographic.mp4",
     "creation_date": "2026-05-05"
   },
@@ -5845,7 +5845,7 @@
       "posters"
     ],
     "base_rank_score": 80,
-    "rank_score": 94,
+    "rank_score": 93.9,
     "intro_video_url": "/video/template_intro/template-history-timeline-infographic.mp4",
     "creation_date": "2026-05-05",
     "allow_generation": true
@@ -5877,7 +5877,7 @@
       "posters"
     ],
     "base_rank_score": 80,
-    "rank_score": 99.2,
+    "rank_score": 97.65,
     "creation_date": "2026-05-05",
     "allow_generation": true
   },
@@ -5910,7 +5910,7 @@
       "nostalgia"
     ],
     "base_rank_score": 80,
-    "rank_score": 93,
+    "rank_score": 93.75,
     "creation_date": "2026-05-05",
     "allow_generation": true
   },
@@ -5943,7 +5943,7 @@
       "posters"
     ],
     "base_rank_score": 80,
-    "rank_score": 96,
+    "rank_score": 97.45,
     "intro_video_url": "/video/template_intro/template-weird-science-facts-infographic.mp4",
     "creation_date": "2026-05-06",
     "allow_generation": true
@@ -5978,7 +5978,7 @@
       "posters"
     ],
     "base_rank_score": 80,
-    "rank_score": 94.6,
+    "rank_score": 94.45,
     "creation_date": "2026-05-06",
     "allow_generation": true
   },
@@ -6011,7 +6011,7 @@
       "posters"
     ],
     "base_rank_score": 90,
-    "rank_score": 105,
+    "rank_score": 104.75,
     "intro_video_url": "/video/template_intro/template-artist-biography-infographic.mp4",
     "creation_date": "2026-05-06",
     "allow_generation": true
@@ -6045,7 +6045,7 @@
       "posters"
     ],
     "base_rank_score": 90,
-    "rank_score": 105.8,
+    "rank_score": 105.35,
     "intro_video_url": "/video/template_intro/template-celebrity-filmography-infographic.mp4",
     "creation_date": "2026-05-06",
     "allow_generation": true
@@ -6079,7 +6079,7 @@
       "film"
     ],
     "base_rank_score": 90,
-    "rank_score": 106,
+    "rank_score": 106.3,
     "creation_date": "2026-05-07",
     "allow_generation": true
   },
@@ -6111,7 +6111,7 @@
       "science"
     ],
     "base_rank_score": 90,
-    "rank_score": 107.4,
+    "rank_score": 107.05,
     "creation_date": "2026-05-07",
     "allow_generation": true
   },
@@ -6144,7 +6144,7 @@
       "design"
     ],
     "base_rank_score": 90,
-    "rank_score": 112.6,
+    "rank_score": 111.1,
     "creation_date": "2026-05-07",
     "allow_generation": true
   },
@@ -6190,7 +6190,7 @@
       "history"
     ],
     "base_rank_score": 90,
-    "rank_score": 107.6,
+    "rank_score": 107.2,
     "creation_date": "2026-05-07"
   },
   {
@@ -6239,7 +6239,7 @@
       "guides"
     ],
     "base_rank_score": 90,
-    "rank_score": 109.2,
+    "rank_score": 109.15,
     "creation_date": "2026-05-09"
   },
   {
@@ -6271,7 +6271,7 @@
       "beauty"
     ],
     "base_rank_score": 90,
-    "rank_score": 109.8,
+    "rank_score": 109.6,
     "creation_date": "2026-05-09",
     "allow_generation": true
   },
@@ -6305,7 +6305,7 @@
       "vocabulary"
     ],
     "base_rank_score": 90,
-    "rank_score": 110.2,
+    "rank_score": 109.9,
     "creation_date": "2026-05-09",
     "allow_generation": true
   },
@@ -6337,7 +6337,7 @@
       "language-english"
     ],
     "base_rank_score": 90,
-    "rank_score": 109.6,
+    "rank_score": 109.45,
     "creation_date": "2026-05-09",
     "allow_generation": true
   },
@@ -6408,7 +6408,7 @@
       "fashion"
     ],
     "base_rank_score": 90,
-    "rank_score": 109.6,
+    "rank_score": 109.45,
     "creation_date": "2026-05-09"
   },
   {
@@ -6471,7 +6471,7 @@
       "weather"
     ],
     "base_rank_score": 90,
-    "rank_score": 110,
+    "rank_score": 110.15,
     "creation_date": "2026-05-10",
     "allow_generation": true
   },
@@ -6503,7 +6503,7 @@
       "interior"
     ],
     "base_rank_score": 90,
-    "rank_score": 110,
+    "rank_score": 110.15,
     "creation_date": "2026-05-10",
     "allow_generation": true
   },
@@ -6536,7 +6536,7 @@
       "comparison"
     ],
     "base_rank_score": 90,
-    "rank_score": 110,
+    "rank_score": 110.15,
     "creation_date": "2026-05-10",
     "allow_generation": true
   },
@@ -6650,7 +6650,7 @@
       "language-english"
     ],
     "base_rank_score": 90,
-    "rank_score": 110,
+    "rank_score": 110.15,
     "creation_date": "2026-05-10",
     "allow_generation": true
   }

--- a/scripts/update_nano_template_rankscore.cjs
+++ b/scripts/update_nano_template_rankscore.cjs
@@ -6,7 +6,7 @@
  *   rank_score = base_rank_score + freshness_bonus + engagement_bonus
  *
  *   freshness_bonus  = max(0, round(20 × (1 − days_old / 14)))   // 0–20
- *   engagement_bonus = min(60, 0.2 × engagement_signal)          // 0–60
+ *   engagement_bonus = min(35, 0.15 × engagement_signal)         // 0–35
  *
  * where days_old comes from each template's creation_date (backfilled
  * here at ~4 templates/day from the end of the file if missing) and
@@ -169,7 +169,7 @@ async function fetchRankScores(client) {
         5  * SUM(CASE WHEN action_type = 'SHARE'    THEN 1 ELSE 0 END)
       ) AS score
     FROM user_interactions
-    WHERE created_at >= NOW() - INTERVAL '3 days'
+    WHERE created_at >= NOW() - INTERVAL '14 days'
       AND content_type NOT IN ('MENU_LINK', 'TOPIC_CAPSULE')
     GROUP BY template_id
     HAVING SUM(
@@ -200,8 +200,8 @@ async function fetchRankScores(client) {
 // where each bonus is capped at 40 so neither component dominates.
 const FRESHNESS_BONUS_MAX = 20;
 const FRESHNESS_WINDOW_DAYS = 14;
-const ENGAGEMENT_WEIGHT = 0.2;
-const ENGAGEMENT_BONUS_MAX = 60;
+const ENGAGEMENT_WEIGHT = 0.15;
+const ENGAGEMENT_BONUS_MAX = 35;
 
 // Used when backfilling creation_date for templates that don't have one.
 // Walks from the end of the file, ~4 templates per day = today, today-1, etc.


### PR DESCRIPTION
Old: 3-day window × 0.2 × cap 60 — 54 of 153 templates had zero engagement (treated as dead) and rankings swung day-to-day on a window shorter than the Tue/Thu cron gap.

New: 14-day window × 0.15 × cap 35 — only 6 templates now have zero engagement, evergreen low-base templates surface (herbal, education- card, language-word-comparison rise into the top 10), and the cap fires for exactly 1 outlier (chinese-verb-opposite, signal 237) so the rest of the engaged distribution stays linear.

Effect on top 10 today:
- template-travel                            136.95 (was 135.8)
- template-chinese-verb-opposite-infographic 135.0  (was 113.2, capped)
- template-theme-overview-poster             131.2  (was 112)
- template-cuisine-food-vocab-poster         120.55
- template-mbti-nba                          120.1

Also updates the curify-studio admin SQL stays as-is — that one tracks the same 3-day window for replication analysis (a separate signal); we can sync the two later if/when desired.