### PR TITLE
Search: surface AI tools hub + 5 supported tools in suggestion index

### DIFF
--- a/app/[locale]/(public)/search/SearchResultsClient.tsx
+++ b/app/[locale]/(public)/search/SearchResultsClient.tsx
@@ -130,7 +130,7 @@ export default function SearchResultsClient({
           {relatedTopics.map((s) => (
             <Link
               key={s.slug}
-              href={`/${locale}/topics/${s.slug}`}
+              href={s.href ? `/${locale}${s.href}` : `/${locale}/topics/${s.slug}`}
               className="inline-flex items-center gap-1.5 rounded-full border border-neutral-200 bg-white px-3 py-1 text-sm text-neutral-700 hover:border-blue-300 hover:text-blue-700 transition-colors"
             >
               {s.emoji && <span>{s.emoji}</span>}
@@ -153,7 +153,7 @@ export default function SearchResultsClient({
             {relatedTopics.map((s) => (
               <Link
                 key={s.slug}
-                href={`/${locale}/topics/${s.slug}`}
+                href={s.href ? `/${locale}${s.href}` : `/${locale}/topics/${s.slug}`}
                 className="inline-flex items-center gap-1.5 rounded-full border border-neutral-200 bg-white px-4 py-2 text-sm text-neutral-700 hover:border-blue-300 hover:text-blue-700 transition-colors"
               >
                 {s.emoji} {renderLabel(s.slug, s.label)}

--- a/app/[locale]/(public)/search/page.tsx
+++ b/app/[locale]/(public)/search/page.tsx
@@ -254,7 +254,9 @@ export default async function SearchPage({ params, searchParams }: Props) {
     // and let the free-text path show a results page that surfaces both.
     if (tokenMatches.length === 1) target = tokenMatches[0];
   }
-  if (target) redirect(`/${locale}/topics/${target.slug}`);
+  if (target) {
+    redirect(target.href ? `/${locale}${target.href}` : `/${locale}/topics/${target.slug}`);
+  }
 
   type InspRecord = {
     id: string;

--- a/app/[locale]/_components/SearchBar.tsx
+++ b/app/[locale]/_components/SearchBar.tsx
@@ -33,12 +33,12 @@ export default function SearchBar({ locale }: Props) {
     ? filterSuggestions(query, 8, localize)
     : DEFAULT_FOCUS_SUGGESTIONS;
 
-  const navigate = useCallback((slug: string, label: string) => {
+  const navigate = useCallback((slug: string, label: string, href?: string) => {
     const q = slug || query.trim();
     track({ contentId: label || q, contentType: "topic_capsule", actionType: "search" });
     setOpen(false);
     setQuery("");
-    router.push(`/${locale}/topics/${q}`);
+    router.push(href ? `/${locale}${href}` : `/${locale}/topics/${q}`);
   }, [locale, query, router, track]);
 
   const handleSubmit = (e: React.FormEvent) => {
@@ -48,11 +48,11 @@ export default function SearchBar({ locale }: Props) {
     track({ contentId: q, contentType: "topic_capsule", actionType: "search" });
     setOpen(false);
     setQuery("");
-    // Try to match a known topic slug; fall back to search results page
+    // Try to match a known topic/tool entry; fall back to search results page
     const exact = filterSuggestions(q, 1, localize)[0];
     const exactLocalized = exact ? localize(exact.slug)?.toLowerCase() : undefined;
     if (exact && (exact.slug === q || exact.label.toLowerCase() === q || exactLocalized === q)) {
-      router.push(`/${locale}/topics/${exact.slug}`);
+      router.push(exact.href ? `/${locale}${exact.href}` : `/${locale}/topics/${exact.slug}`);
     } else {
       router.push(`/${locale}/search?q=${encodeURIComponent(q)}`);
     }
@@ -108,7 +108,7 @@ export default function SearchBar({ locale }: Props) {
               <button
                 key={s.slug}
                 type="button"
-                onClick={() => navigate(s.slug, renderLabel(s.slug, s.label))}
+                onClick={() => navigate(s.slug, renderLabel(s.slug, s.label), s.href)}
                 className="inline-flex items-center gap-1.5 rounded-full border border-neutral-200 bg-neutral-50 px-3 py-1.5 text-sm text-neutral-700 hover:border-blue-300 hover:bg-blue-50 hover:text-blue-700 transition-colors cursor-pointer"
               >
                 {s.emoji && <span aria-hidden="true">{s.emoji}</span>}

--- a/lib/searchIndex.ts
+++ b/lib/searchIndex.ts
@@ -12,6 +12,12 @@ export type SuggestionEntry = {
    * Keep these short and lowercase.
    */
   aliases?: readonly string[];
+  /**
+   * Optional URL override (without locale prefix, leading slash required).
+   * When set, the search UI navigates here instead of `/topics/<slug>`.
+   * Used for entries that point at non-topic destinations like /tools.
+   */
+  href?: string;
 };
 
 // Tier 2 — primary navigational topics (shown by default on focus)
@@ -124,6 +130,78 @@ export const DEFAULT_FOCUS_SUGGESTIONS: SuggestionEntry[] = [
   { slug: "cartoon",        label: "Cartoon",        emoji: "🖌️",   tier: 3 },
 ];
 
+// Tools — overall /tools page + each tool with status === "create" in
+// lib/tools-registry.ts. Use `href` so navigation goes to the tool route
+// instead of /topics/<slug>. Keep slugs in sync with tools-registry.
+export const TOOL_SUGGESTIONS: SuggestionEntry[] = [
+  {
+    slug: "tools",
+    href: "/tools",
+    label: "AI Tools",
+    emoji: "🛠️",
+    tier: 2,
+    aliases: ["tool", "ai tools", "studio tools", "utilities", "工具", "ai 工具", "herramientas"],
+  },
+  {
+    slug: "video-dubbing",
+    href: "/tools/video-dubbing",
+    label: "Video Dubbing",
+    emoji: "🎙️",
+    tier: 3,
+    aliases: [
+      "dub", "dubbing", "voice over", "translate video", "video translation",
+      "配音", "视频配音", "doblaje", "doblar video",
+    ],
+  },
+  {
+    slug: "bilingual-subtitles",
+    href: "/tools/bilingual-subtitles",
+    label: "Bilingual Subtitles",
+    emoji: "💬",
+    tier: 3,
+    aliases: [
+      "subtitle", "subtitles", "captions", "captioner", "srt",
+      "bilingual subtitles", "subtitle captioner",
+      "字幕", "双语字幕", "subtítulos", "subtítulos bilingües",
+    ],
+  },
+  {
+    slug: "video-transcript-generator",
+    href: "/tools/video-transcript-generator",
+    label: "Video Transcript",
+    emoji: "📝",
+    tier: 3,
+    aliases: [
+      "transcript", "transcribe", "transcription", "video to text",
+      "speech to text", "stt",
+      "转录", "视频转文字", "transcripción", "transcribir video",
+    ],
+  },
+  {
+    slug: "video-summarizer",
+    href: "/tools/video-summarizer",
+    label: "Video Summarizer",
+    emoji: "🎬",
+    tier: 3,
+    aliases: [
+      "summarize", "summarize video", "video summary", "summary", "tldr",
+      "视频总结", "视频摘要", "resumen", "resumen de video",
+    ],
+  },
+  {
+    slug: "speech-translator",
+    href: "/tools/speech-translator",
+    label: "Speech Translator",
+    emoji: "🗣️",
+    tier: 3,
+    aliases: [
+      "speech translation", "voice translator", "translate audio",
+      "audio translator", "real time translation",
+      "语音翻译", "实时翻译", "traductor de voz", "traducir voz",
+    ],
+  },
+];
+
 export const ALL_SUGGESTIONS: SuggestionEntry[] = [
   ...TIER2_SUGGESTIONS,
   ...TIER1_SUGGESTIONS,
@@ -131,6 +209,7 @@ export const ALL_SUGGESTIONS: SuggestionEntry[] = [
   ...TIER3_STYLE,
   ...TIER3_MBTI,
   ...TIER3_SUBJECT,
+  ...TOOL_SUGGESTIONS,
 ];
 
 // ── Fuzzy matching ──────────────────────────────────────────────────────────


### PR DESCRIPTION
Adds TOOL_SUGGESTIONS to lib/searchIndex.ts so queries like "dubbing", "subtitles", "transcribe", "summarize", "speech translation" (plus zh/es synonyms) match and route directly to /tools or the specific tool page.

Five supported tools are wired (status === "create" in lib/tools-registry.ts): video-dubbing, bilingual-subtitles, video-transcript-generator, video-summarizer, speech-translator. Plus an overall "tools" hub entry for /tools. Coming-soon tools are intentionally omitted.

Mechanism: SuggestionEntry gets an optional `href` override. When set, SearchBar.navigate, the search-page redirect, and the related-topic chips in SearchResultsClient route to `/{locale}{href}` instead of the default `/{locale}/topics/{slug}`.

Touches:
- lib/searchIndex.ts: SuggestionEntry.href, TOOL_SUGGESTIONS, included in ALL_SUGGESTIONS
- app/[locale]/_components/SearchBar.tsx: navigate(slug, label, href)
- app/[locale]/(public)/search/page.tsx: redirect honors target.href
- app/[locale]/(public)/search/SearchResultsClient.tsx: chip Links honor s.href