### PR TITLE
blog: shared top bar with search + breadcrumb + locale switcher

### DIFF
--- a/app/[locale]/(public)/blog/[slug]/components/StandardBlogPost.tsx
+++ b/app/[locale]/(public)/blog/[slug]/components/StandardBlogPost.tsx
@@ -1,7 +1,6 @@
 import { getTranslations } from "next-intl/server";
 import { notFound } from "next/navigation";
 import CdnImage from "@/app/[locale]/_components/CdnImage";
-import BreadcrumbNavigation from "./BreadcrumbNavigation";
 import StructuredData from "./StructuredData";
 import TableOfContents from "./TableOfContents";
 import PromptBox from "./PromptBox";
@@ -46,7 +45,6 @@ export default async function StandardBlogPost({
 
   return (
     <article className="pt-20 pb-12 text-[18px] leading-8 lg:pr-12 lg:pl-8 pl-4 pr-4 md:pl-8 md:pr-8">
-      <BreadcrumbNavigation items={[{ name: "Blog", href: "/blog" }, { name: safeT("title"), href: `/blog/${slug}` }]} />
       <StructuredData 
         title={safeT("title")}
         description={safeT("metaDescription")}

--- a/app/[locale]/(public)/blog/_components/BlogTopBar.tsx
+++ b/app/[locale]/(public)/blog/_components/BlogTopBar.tsx
@@ -1,0 +1,81 @@
+"use client";
+
+import { usePathname } from "next/navigation";
+import Link from "next/link";
+import { useMemo } from "react";
+import { ChevronRight } from "lucide-react";
+
+import SearchBar from "@/app/[locale]/_components/SearchBar";
+import LocaleSwitcher from "@/app/[locale]/_components/LocaleSwitcher";
+import blogs from "@/public/data/blogs.json";
+
+type BlogIndexEntry = { slug: string; title: string };
+
+function stripLocale(pathname: string): string {
+  return pathname.replace(/^\/[a-zA-Z]{2}(?=\/|$)/, "") || "/";
+}
+
+function humanizeSlug(slug: string): string {
+  return slug
+    .replace(/[-_]+/g, " ")
+    .replace(/\b\w/g, (c) => c.toUpperCase());
+}
+
+export default function BlogTopBar({ locale }: { locale: string }) {
+  const pathname = usePathname();
+
+  const breadcrumbItems = useMemo(() => {
+    const path = stripLocale(pathname);
+    const segments = path.split("/").filter(Boolean);
+    // segments will be ["blog"] for the list, or ["blog", "<slug>"] for a post.
+    const localePrefix = locale === "en" ? "" : `/${locale}`;
+
+    const items: { name: string; href?: string }[] = [
+      { name: "Home", href: `${localePrefix}/` },
+      { name: "Blog", href: `${localePrefix}/blog` },
+    ];
+
+    if (segments[0] === "blog" && segments[1]) {
+      const slug = decodeURIComponent(segments[1]);
+      const entry = (blogs as BlogIndexEntry[]).find((b) => b.slug === slug);
+      items.push({ name: entry?.title ?? humanizeSlug(slug) });
+    }
+
+    // Mark the last entry as current (no href).
+    items[items.length - 1] = { ...items[items.length - 1], href: undefined };
+    return items;
+  }, [pathname, locale]);
+
+  return (
+    <div className="sticky top-0 z-40 bg-[#FDFDFD]/95 backdrop-blur px-4 pt-3 pb-3 -mx-4 -mt-4 mb-6 md:-mx-8 md:px-8 lg:-mx-12 lg:px-12 border-b border-neutral-200/60">
+      {/* Row 1: search (flex-1) + locale switcher (desktop only — mobile uses Header's floater) */}
+      <div className="flex items-start gap-4">
+        <div className="flex-1 min-w-0">
+          <SearchBar locale={locale} />
+        </div>
+        <div className="hidden lg:block shrink-0">
+          <LocaleSwitcher />
+        </div>
+      </div>
+
+      {/* Row 2: breadcrumb */}
+      <nav
+        aria-label="Breadcrumb"
+        className="mt-3 flex flex-wrap items-center gap-x-1 gap-y-1 text-sm text-neutral-600"
+      >
+        {breadcrumbItems.map((item, i) => (
+          <div key={`${item.name}-${i}`} className="flex items-center">
+            {i > 0 && <ChevronRight className="mx-1 h-4 w-4 text-neutral-400" aria-hidden="true" />}
+            {item.href ? (
+              <Link href={item.href} className="hover:text-neutral-900 transition-colors">
+                {item.name}
+              </Link>
+            ) : (
+              <span className="text-neutral-900 font-medium line-clamp-1">{item.name}</span>
+            )}
+          </div>
+        ))}
+      </nav>
+    </div>
+  );
+}

--- a/app/[locale]/(public)/blog/ai-collage-digital-wallpaper-guide/page.tsx
+++ b/app/[locale]/(public)/blog/ai-collage-digital-wallpaper-guide/page.tsx
@@ -5,7 +5,6 @@ import Link from 'next/link';
 import CdnImage from '@/app/[locale]/_components/CdnImage';
 import RelatedBlogs from "../../../_components/RelatedBlogs";
 import TableOfContents from "@/app/[locale]/(public)/blog/[slug]/components/TableOfContents";
-import BreadcrumbNavigation from "@/app/[locale]/(public)/blog/[slug]/components/BreadcrumbNavigation";
 import StructuredData from "@/app/[locale]/(public)/blog/[slug]/components/StructuredData";
 import PromptBox from "@/app/[locale]/(public)/blog/[slug]/components/PromptBox";
 import NanoBananaExamples from "@/app/[locale]/(public)/blog/[slug]/NanoBananaExamples";
@@ -25,10 +24,6 @@ export default function AICollageWallpaperGuide() {
 
   return (
     <article className="pt-20 pb-12 text-[18px] leading-8 lg:pr-12 lg:pl-8 pl-4 pr-4 md:pl-8 md:pr-8">
-      <BreadcrumbNavigation items={[
-        { name: 'Blog', href: '/blog' },
-        { name: t('title'), href: '/blog/ai-collage-digital-wallpaper-guide' }
-      ]} />
       <StructuredData 
         title={t('title')}
         description={t('metaDescription')}

--- a/app/[locale]/(public)/blog/how-to-dub-videos-naturally/page.tsx
+++ b/app/[locale]/(public)/blog/how-to-dub-videos-naturally/page.tsx
@@ -21,7 +21,6 @@ import CdnImage from '@/app/[locale]/_components/CdnImage';
 import RelatedBlogs from "../../../_components/RelatedBlogs";
 import TableOfContents from "@/app/[locale]/(public)/blog/[slug]/components/TableOfContents";
 import ShareButton from "@/app/[locale]/_components/ShareButton";
-import BreadcrumbNavigation from "@/app/[locale]/(public)/blog/[slug]/components/BreadcrumbNavigation";
 import StructuredData from "@/app/[locale]/(public)/blog/[slug]/components/StructuredData";
 import FAQSection from "@/app/[locale]/(public)/blog/[slug]/components/FAQSection";
 import PromptBox from "@/app/[locale]/(public)/blog/[slug]/components/PromptBox";
@@ -66,14 +65,6 @@ export default function HowToDubVideosNaturallyPage() {
   return (
     <article className="pt-20 pb-12 text-[18px] leading-8 lg:pr-12 lg:pl-8 pl-4 pr-4 md:pl-8 md:pr-8">
       {/* Breadcrumb Navigation */}
-      <BreadcrumbNavigation 
-        items={[
-          { name: "Home", href: "/" },
-          { name: "Blog", href: "/blog" },
-          { name: t('hero.title'), href: `/blog/how-to-dub-videos-naturally` }
-        ]}
-      />
-      
       <div className="prose prose-base md:prose-lg">
         {/* Hero Section */}
         <div className="relative mb-8">

--- a/app/[locale]/(public)/blog/layout.tsx
+++ b/app/[locale]/(public)/blog/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { getTranslations } from "next-intl/server";
 import BlogShareBar from "./BlogShareBar";
+import BlogTopBar from "./_components/BlogTopBar";
 
 export async function generateMetadata({
   params,
@@ -35,12 +36,13 @@ export default async function BlogLayout({
   children: React.ReactNode;
   params: Promise<{ locale: string }>;
 }) {
-  await params;
+  const { locale } = await params;
 
   return (
     <main className="min-h-screen bg-[#FDFDFD] px-4 pt-4 pb-10 md:px-8 lg:px-12">
       <div className="mx-auto w-full max-w-[1400px]">
         <div className="min-w-0">
+          <BlogTopBar locale={locale} />
           {children}
           <BlogShareBar />
         </div>

--- a/app/[locale]/(public)/blog/mbti-character-generator/page.tsx
+++ b/app/[locale]/(public)/blog/mbti-character-generator/page.tsx
@@ -23,7 +23,6 @@ import CdnImage from '@/app/[locale]/_components/CdnImage';
 import RelatedBlogs from "../../../_components/RelatedBlogs";
 import TableOfContents from "@/app/[locale]/(public)/blog/[slug]/components/TableOfContents";
 import ShareButton from "@/app/[locale]/_components/ShareButton";
-import BreadcrumbNavigation from "@/app/[locale]/(public)/blog/[slug]/components/BreadcrumbNavigation";
 import StructuredData from "@/app/[locale]/(public)/blog/[slug]/components/StructuredData";
 import FAQSection from "@/app/[locale]/(public)/blog/[slug]/components/FAQSection";
 import PromptBox from "@/app/[locale]/(public)/blog/[slug]/components/PromptBox";
@@ -106,14 +105,6 @@ export default function MBTICharacterGeneratorPage() {
   return (
     <div className="pt-10 pb-8">
       {/* Breadcrumb Navigation */}
-      <BreadcrumbNavigation 
-        items={[
-          { name: "Home", href: "/" },
-          { name: "Blog", href: "/blog" },
-          { name: t('hero.title'), href: `/blog/mbti-character-generator` }
-        ]}
-      />
-      
       <article className="prose prose-base md:prose-lg">
         {/* Hero Section */}
         <div className="relative mb-8">

--- a/app/[locale]/(public)/blog/mbti-relationship-style-visualizer/page.tsx
+++ b/app/[locale]/(public)/blog/mbti-relationship-style-visualizer/page.tsx
@@ -5,7 +5,6 @@ import Link from 'next/link';
 import CdnImage from '@/app/[locale]/_components/CdnImage';
 import RelatedBlogs from "../../../_components/RelatedBlogs";
 import TableOfContents from "@/app/[locale]/(public)/blog/[slug]/components/TableOfContents";
-import BreadcrumbNavigation from "@/app/[locale]/(public)/blog/[slug]/components/BreadcrumbNavigation";
 import StructuredData from "@/app/[locale]/(public)/blog/[slug]/components/StructuredData";
 import PromptBox from "@/app/[locale]/(public)/blog/[slug]/components/PromptBox";
 import { makeNanoTemplateUrl } from "@/lib/nano_utils";
@@ -26,10 +25,6 @@ export default function MBTIRelationshipStyleVisualizer() {
 
   return (
     <article className="pt-20 pb-12 text-[18px] leading-8 lg:pr-12 lg:pl-8 pl-4 pr-4 md:pl-8 md:pr-8">
-      <BreadcrumbNavigation items={[
-        { name: 'Blog', href: '/blog' },
-        { name: t('title'), href: '/blog/mbti-relationship-style-visualizer' }
-      ]} />
       <StructuredData 
         title={t('title')}
         description={t('metaDescription')}

--- a/app/[locale]/(public)/blog/ultimate-directory-of-nano-banana-prompts/page.tsx
+++ b/app/[locale]/(public)/blog/ultimate-directory-of-nano-banana-prompts/page.tsx
@@ -22,7 +22,6 @@ import { useState, useMemo } from 'react';
 import CdnImage from '@/app/[locale]/_components/CdnImage';
 import RelatedBlogs from "../../../_components/RelatedBlogs";
 import TableOfContents from "@/app/[locale]/(public)/blog/[slug]/components/TableOfContents";
-import BreadcrumbNavigation from "@/app/[locale]/(public)/blog/[slug]/components/BreadcrumbNavigation";
 import StructuredData from "@/app/[locale]/(public)/blog/[slug]/components/StructuredData";
 import PromptBox from "@/app/[locale]/(public)/blog/[slug]/components/PromptBox";
 import nanoTemplatesData from '../../../../../public/data/nano_templates.json';
@@ -302,14 +301,6 @@ export default function UltimateDirectoryOfNanoBananaPromptsPage() {
   return (
     <div className="pt-10 pb-8">
       {/* Breadcrumb Navigation */}
-      <BreadcrumbNavigation 
-        items={[
-          { name: "Home", href: "/" },
-          { name: "Blog", href: "/blog" },
-          { name: t('hero.title'), href: `/blog/ultimate-directory-of-nano-banana-prompts` }
-        ]}
-      />
-
       <article className="prose prose-base md:prose-lg max-w-6xl mx-auto px-4 sm:px-6 lg:px-8">
         {/* Hero Section */}
         <div className="relative mb-12">

--- a/app/[locale]/(public)/blog/weird-science-facts-classroom-engagement/page.tsx
+++ b/app/[locale]/(public)/blog/weird-science-facts-classroom-engagement/page.tsx
@@ -5,7 +5,6 @@ import Link from 'next/link';
 import CdnImage from '@/app/[locale]/_components/CdnImage';
 import RelatedBlogs from "../../../_components/RelatedBlogs";
 import TableOfContents from "@/app/[locale]/(public)/blog/[slug]/components/TableOfContents";
-import BreadcrumbNavigation from "@/app/[locale]/(public)/blog/[slug]/components/BreadcrumbNavigation";
 import StructuredData from "@/app/[locale]/(public)/blog/[slug]/components/StructuredData";
 import PromptBox from "@/app/[locale]/(public)/blog/[slug]/components/PromptBox";
 
@@ -24,10 +23,6 @@ export default function WeirdScienceFactsClassroomEngagement() {
 
   return (
     <article className="pt-20 pb-12 text-[18px] leading-8 lg:pr-12 lg:pl-8 pl-4 pr-4 md:pl-8 md:pr-8">
-      <BreadcrumbNavigation items={[
-        { name: 'Blog', href: '/blog' },
-        { name: t('title'), href: '/blog/weird-science-facts-classroom-engagement' }
-      ]} />
       <StructuredData 
         title={t('title')}
         description={t('metaDescription')}


### PR DESCRIPTION
The site-wide SiteTopBar returns null on /blog routes, so blog pages had no search bar or locale switcher, and breadcrumbs were duplicated per-page (6 individual pages + StandardBlogPost each rendered their own BreadcrumbNavigation, all with slightly different shapes).

New BlogTopBar mounted once in the blog layout:
  - SearchBar (full width, sticky to top, same behavior as SiteTopBar)
  - LocaleSwitcher (desktop only — mobile already has the floater rendered by Header)
  - Auto-derived breadcrumb from pathname: Home > Blog > <post title>
    Title is looked up from public/data/blogs.json by slug; falls back to humanized slug if not indexed.

Stripped the per-page <BreadcrumbNavigation> import + JSX from:
  - weird-science-facts-classroom-engagement
  - how-to-dub-videos-naturally
  - ultimate-directory-of-nano-banana-prompts
  - mbti-relationship-style-visualizer
  - mbti-character-generator
  - ai-collage-digital-wallpaper-guide
  - [slug]/components/StandardBlogPost The BreadcrumbNavigation component itself is left in place since it's small and might be useful for any future bespoke breadcrumb case.