### PR TITLE
Use toCdnUrl from CdnImage for carousel image src

### DIFF
--- a/app/[locale]/(public)/carousel/CarouselClient.tsx
+++ b/app/[locale]/(public)/carousel/CarouselClient.tsx
@@ -25,8 +25,8 @@ import { TransformWrapper, TransformComponent } from "react-zoom-pan-pinch";
 
 import ExampleVideoPlayer from "@/app/[locale]/(public)/nano-template/[slug]/example/[exampleId]/ExampleVideoPlayer";
 import ExampleRightColumn from "@/app/[locale]/(public)/nano-template/[slug]/example/[exampleId]/ExampleRightColumn";
+import { toCdnUrl } from "@/app/[locale]/_components/CdnImage";
 import { useTracking } from "@/services/useTracking";
-import { cdn } from "@/lib/cdn";
 import { useIsMobileLikeDevice } from "@/lib/device";
 import type { TemplateParameter } from "@/lib/nano_utils";
 import type { ExistingExampleRef } from "@/lib/editDistance";
@@ -64,7 +64,7 @@ function ProgressiveSlideImage({
       return;
     }
     const img = new window.Image();
-    img.src = cdn(fullSrc);
+    img.src = toCdnUrl(fullSrc);
     img.onload = () => {
       setSrc(fullSrc);
       onFullLoaded?.();
@@ -73,7 +73,7 @@ function ProgressiveSlideImage({
 
   return (
     <img
-      src={cdn(src)}
+      src={toCdnUrl(src)}
       alt={alt}
       draggable={false}
       className="max-h-full max-w-full select-none"


### PR DESCRIPTION
The carousel was calling lib/cdn.cdn() which assumes its input is always a relative path. For absolute URLs (the shape returned by the nano- banana-pro-prompts API) it added a leading slash and produced /https://cdn.curify-ai.com/... — which the browser resolved against the current origin, yielding a 404 on the prompt-gallery carousel.

Switch to toCdnUrl from CdnImage. That helper already handles both shapes (absolute → pass through; relative /images|/video|/audio prefixes → prepend CDN base), so the same code now works for templates (relative paths in nano_inspiration.json) and prompts (absolute URLs from the Azure API).