### PR TITLE
SEO/sitemap: shorten edge cache so deploys reflect within 5 min

### DIFF
--- a/app/sitemap-blogs.xml/route.ts
+++ b/app/sitemap-blogs.xml/route.ts
@@ -92,7 +92,7 @@ ${urls}
   return new NextResponse(xml, {
     headers: {
       "Content-Type": "application/xml",
-      "Cache-Control": "public, max-age=3600",
+      "Cache-Control": "public, s-maxage=300, stale-while-revalidate=3600",
     },
   });
 }

--- a/app/sitemap-examples.xml/route.ts
+++ b/app/sitemap-examples.xml/route.ts
@@ -170,7 +170,7 @@ ${urls}
   return new NextResponse(xml, {
     headers: {
       "Content-Type": "application/xml",
-      "Cache-Control": "public, max-age=3600",
+      "Cache-Control": "public, s-maxage=300, stale-while-revalidate=3600",
     },
   });
 }

--- a/app/sitemap-index.xml/route.ts
+++ b/app/sitemap-index.xml/route.ts
@@ -41,7 +41,7 @@ ${entries}
   return new NextResponse(xml, {
     headers: {
       "Content-Type": "application/xml",
-      "Cache-Control": "public, max-age=3600",
+      "Cache-Control": "public, s-maxage=300, stale-while-revalidate=3600",
     },
   });
 }

--- a/app/sitemap.xml/route.ts
+++ b/app/sitemap.xml/route.ts
@@ -242,7 +242,7 @@ ${urls}
   return new NextResponse(xml, {
     headers: {
       "Content-Type": "application/xml",
-      "Cache-Control": "public, max-age=3600",
+      "Cache-Control": "public, s-maxage=300, stale-while-revalidate=3600",
     },
   });
 }


### PR DESCRIPTION
All four sitemap routes were serving Cache-Control: public, max-age=3600, which forced both browsers and the Vercel edge to hold the prior body for a full hour after deploy. That made testing fresh lastmod bumps painful — required ?v=now to bust the cache key.

Swap to public, s-maxage=300, stale-while-revalidate=3600:
  - Edge revalidates every 5 min, so deploys surface quickly
  - stale-while-revalidate keeps response time fast (serve stale, refresh async)
  - No browser max-age — sitemap fetches are infrequent enough that skipping the browser cache is fine, and avoids stale-browser confusion when iterating