### PR TITLE
SiteTopBar: stabilize EntryBar fold — absolute positioning, no transi…

### DIFF
--- a/app/[locale]/_layout_components/SiteTopBar.tsx
+++ b/app/[locale]/_layout_components/SiteTopBar.tsx
@@ -98,8 +98,14 @@ export default function SiteTopBar({ locale }: { locale: string }) {
         </div>
         <LocaleSwitcher />
       </div>
+      {/* EntryBar is absolutely positioned just below the SearchBar row
+          rather than living in the sticky bar's flow. Toggling its
+          visibility no longer changes the sticky bar's height, so the
+          page content below never reflows — which was the source of the
+          scroll-up flash. Pure conditional render with no transition:
+          the bar snaps in/out, no slide, no dissolve. */}
       {!hideEntryBar && !entryBarFolded && (
-        <div className="mt-3">
+        <div className="absolute left-0 right-0 top-full px-4 pb-3 bg-[#FDFDFD]/95 backdrop-blur">
           <EntryBar locale={locale} />
         </div>
       )}


### PR DESCRIPTION
…tion

Two compounding sources of flash:
1. Mount/unmount changed the sticky bar height, which reflowed the page content below — the content shift read as a flash on every scroll-up.
2. The transform slide / opacity dissolve overlaid the visual motion of the bar appearing on top of that reflow.

Fix:
- Pull EntryBar out of the sticky bar flow. The component now renders as position: absolute, anchored at top-full just below the SearchBar row. Mounting / unmounting it no longer changes the sticky bar height, so no page reflow.
- Drop the transition-transform + translate dance. Bar is rendered only when not folded, no animation, no opacity fade. Snaps in / snaps out.

The RAF-throttled 30 px direction accumulator from the previous turn stays — it decides when the fold flips, so inertial or touchpad bounce within a single gesture cannot toggle the state more than once.