### PR TITLE
searchRewrite: fix Path B over-rejection for Korean / historical figu…

### DIFF
--- a/lib/searchRewrite.ts
+++ b/lib/searchRewrite.ts
@@ -88,8 +88,8 @@ cover like "stock prices" or "tax software"):
     a misleading rewrite — worse than an empty result page.
 
 Examples of empty-return (use Path B ONLY when the query is clearly outside
-any visual / creative / cultural domain — NOT for pop-culture names you
-don't recognize, which the catalog CAN template via fandom-grid / MBTI):
+any visual / creative / cultural domain — NOT for pop-culture names,
+historical figures, places, or generic concepts in any language):
 - "زوحين" → [] (random non-Latin letters that don't form a recognizable word)
 - "ddd" → [] (random keystrokes)
 - "asjdkfh" → [] (random)
@@ -99,19 +99,50 @@ don't recognize, which the catalog CAN template via fandom-grid / MBTI):
 - "stock prices" → [] (finance data, not visual)
 - "tax software" → [] (business utility, not visual)
 
-CRITICAL: pop-culture names, anime / game franchises, celebrities, public
-figures, films, TV shows, fashion brands → ALWAYS Path A (template-mbti-*
-or template-fandom-character-grid-poster can handle them):
-- "Genshin Impact", "Genshin", "原神" → Path A (anime / fandom MBTI)
-- "Bridgerton" → Path A (period drama / regency fashion)
-- "Taylor Swift" → Path A (celebrity / music portrait)
-- "Stranger Things" → Path A (fandom MBTI / character grid)
-- "Chiikawa" → Path A (kawaii anime characters)
+CRITICAL: any of the following → ALWAYS Path A. The catalog can template
+them via mbti-*, fandom-character-grid, historical-figure-profile,
+artist-biography, travel, culture, music-style-visual, dance, or vocabulary
+templates. Recognize transliterations across Chinese / Japanese / Korean /
+Russian / Spanish / French / Arabic and route them the same way as the
+English form:
+
+  - Pop-culture: anime/manga, game franchises, films, TV shows
+    e.g. "Genshin Impact" / "原神" / "겐신" → Path A
+    e.g. "Bridgerton" → Path A
+    e.g. "Stranger Things" → Path A
+    e.g. "Chiikawa" / "ちいかわ" / "吉伊卡哇" → Path A
+
+  - Celebrities, athletes, artists, public figures:
+    e.g. "Taylor Swift" / "테일러 스위프트" → Path A
+    e.g. "BTS" / "방탄소년단" → Path A
+
+  - Historical / notable figures (scientists, philosophers, leaders, artists):
+    e.g. "Einstein" / "아인슈타인" / "爱因斯坦" → Path A (character-analysis,
+         historical-figure-profile, artist-biography templates)
+    e.g. "Newton" / "뉴턴" / "牛顿" → Path A
+    e.g. "Marie Curie" / "퀴리 부인" → Path A
+    e.g. "Confucius" / "孔子" → Path A
+
+  - Country / region / city names in ANY language:
+    e.g. "Korea" / "한국" / "韓国" → Path A (travel + culture + food + costume)
+    e.g. "China" / "中国" / "중국" → Path A
+    e.g. "Paris" / "巴黎" / "파리" → Path A
+    e.g. "Japan" / "日本" / "일본" → Path A
+
+  - Generic creative-domain concepts even when stated as bare nouns:
+    e.g. "music" / "音乐" / "음악" → Path A (music-style-visual-infographic)
+    e.g. "animation" / "动画" / "애니메이션" → Path A (animation-studio-comparison)
+    e.g. "company" / "회사" / "公司" → Path A (business / professional vocabulary
+         or category-guide-infographic — DON'T conflate with "Salesforce")
 
 Examples of valid rewrites:
 - "手作" → ["crafting templates", "diy watercolor", "scrapbook design"]
 - "唯美春天" → ["watercolor spring", "spring flowers", "aesthetic florals"]
 - "证件照" → ["passport photo portrait", "professional headshot", "证件 风格头像"]
+- "아인슈타인" → ["Einstein character poster", "Einstein historical figure", "scientist biography infographic"]
+- "한국" → ["Korea travel poster", "Korean culture infographic", "Korean food vocabulary"]
+- "음악" → ["music style infographic", "music genre poster", "music vocabulary card"]
+- "회사" → ["company professional guide", "business category infographic", "office lifestyle"]
 
 LITERAL-NOUN RULE: a literal noun query (single object the user wants
 to see — 鲜花 fresh flowers, 蛋糕 cake, 戒指 ring, 蜡烛 candle, 茶具 teapot,


### PR DESCRIPTION
…res / places / generic nouns

Root cause traced via the new diagnostic logging (commit e8f93ab). Korean query "아인슈타인" returned parsed=[] from gpt-4o-mini. Reproduced locally with 6/6 Korean queries returning [] under the current prompt:

  아인슈타인 → []   한국 → []   음악 → []
  회사 → []        중국 → []   애니메이션 → []

The prompt's CRITICAL clause whitelisted only English pop-culture anchors (Genshin Impact, Bridgerton, Taylor Swift, Stranger Things, Chiikawa). The model pattern-matched: "not in my Path A whitelist → Path B → []". Korean transliterations, historical figures, country names, and bare generic nouns all got rejected as off-catalog.

Patch: extend the CRITICAL clause to also include:

  - Historical / notable figures (scientists, philosophers, leaders, artists) — Einstein / 아인슈타인 / 爱因斯坦, Newton, Marie Curie, Confucius. Catalog has historical-figure-profile, character- analysis, artist-biography templates that can handle them.
  - Country / region / city names in ANY language — Korea / 한국 / 韓国, China / 中国 / 중국, Paris / 巴黎 / 파리, Japan / 日本 / 일본. Catalog has travel + culture + food + costume coverage.
  - Generic creative-domain concepts even as bare nouns — music / 音乐 / 음악, animation / 动画 / 애니메이션, company / 회사 / 公司. Catalog has music-style-visual-infographic, animation-studio- comparison, professional-category-guide-infographic.

Also added explicit "recognize transliterations" line in the CRITICAL preamble so the model knows transliterated forms route the same way as English.

Plus added 4 worked rewrite examples specifically for the failing cases (아인슈타인, 한국, 음악, 회사) — explicit examples cue the model better than abstract rules.

Validation (gpt-4o-mini, max_tokens=400):

  Path A — now rescued:
    아인슈타인 → ["Einstein character poster", "Einstein historical figure", ...]
    한국 → ["Korea travel poster", "Korean culture infographic", ...]
    음악 → ["music style infographic", "music genre poster", ...]
    회사 → ["company professional guide", "business category infographic", ...]
    중국 → ["China travel poster", "Chinese culture infographic", ...]
    애니메이션 → ["animation style infographic", "animation studio comparison", ...]
    한국 음식 → ["Korean food vocabulary", "Korean cuisine infographic", ...]
    BTS → ["BTS character profile", "BTS music style infographic", ...]
    Einstein → (same as 아인슈타인)
    日本 → ["Japan travel poster", ...]
    原神 → ["Genshin Impact character cards", ...]

  Path B — still correctly empty (no regression):
    زوحين → []          ddd → []
    Salesforce → []     QuickBooks → []
    Zhang Wei → []      stock prices → []
    tax software → []

  Known still-failing (out of prompt scope — content/alias gap):
    accion → []  (Spanish "action" without accent — model treats as
                  ambiguous; needs content or alias top-up per the
                  e3047d2 commit note from 2026-05-23)

Inspiration-richness eval: 52/54 PASS (same 2 pre-existing benign WARNs, no new regression). Eval doesn't test rewriter directly — run with --rewrite flag to validate rewrite recovery if needed.