### PR TITLE
search: gate LLM rewriter on bot-UA + garbage-query check

### DIFF
--- a/app/[locale]/(public)/search/page.tsx
+++ b/app/[locale]/(public)/search/page.tsx
@@ -1,4 +1,5 @@
 import { redirect } from "next/navigation";
+import { headers } from "next/headers";
 import type { Metadata } from "next";
 import { getTranslations } from "next-intl/server";
 import nanoInspiration from "@/public/data/nano_inspiration.json";
@@ -22,6 +23,29 @@ import SearchResultsClient from "./SearchResultsClient";
 // client-side LOW_RESULT_THRESHOLD in SearchResultsClient so the tracking
 // boundary stays consistent.
 const LOW_RESULT_THRESHOLD = 3;
+
+// Bots / crawlers we do NOT want triggering paid LLM rewriter calls.
+// Observed in Vercel logs hitting /search with garbage queries (bingbot
+// querying "MuMu_5.0.11_LxoFNKC 32bit", etc). The rewriter still runs
+// for real users — bots just get the empty-result rendering.
+const BOT_UA_REGEX = /bot|crawler|spider|claudebot|gptbot|chatgpt|bingbot|googlebot|ahrefs|semrushbot|facebookexternalhit|baiduspider|duckduckbot|yandexbot|sogou|petalbot|applebot|amazonbot|mj12bot|seekport|exabot|datadog|uptimerobot/i;
+
+// Garbage-query heuristic — queries unlikely to map to any creative
+// catalog content, so skip the paid LLM rewriter. Looks for: version
+// strings (1.2.3), long underscored tokens (LxoFNKC_32bit), file
+// extensions, long alphanumeric blobs with no spaces. Real user queries
+// don't look like this.
+function looksLikeGarbageQuery(q: string): boolean {
+  const t = q.trim();
+  if (t.length < 2) return true;
+  if (/\d+\.\d+\.\d+/.test(t)) return true;                  // 1.2.3 version
+  if (/\.[a-z]{2,4}(?:\s|$)/i.test(t)) return true;          // file extension
+  if (/_[a-z0-9]{4,}_|_[a-z0-9]{4,}\s|\s[a-z0-9]{4,}_/i.test(t)) return true;  // underscored ID-shape tokens
+  if (/^[a-z0-9]{20,}$/i.test(t)) return true;               // long alnum blob
+  // Single very long token (no spaces) with mixed case/digits — likely an ID
+  if (!/\s/.test(t) && t.length > 25 && /\d/.test(t) && /[A-Z]/.test(t) && /[a-z]/.test(t)) return true;
+  return false;
+}
 
 // Build once per request — small enough to recompute, big enough we don't want
 // to do it inside the inspiration loop.
@@ -485,7 +509,18 @@ export default async function SearchPage({ params, searchParams }: Props) {
   const initialThinCount =
     baseResult.scored.filter((s) => s.strict).length +
     matchedTemplateIdsByI18nUnion.size;
-  if (initialThinCount < LOW_RESULT_THRESHOLD && query.length >= 2) {
+  // Gate the paid LLM rewriter on (a) thin results, (b) non-bot UA,
+  // (c) query doesn't look like garbage (version strings, file IDs,
+  // long alphanumeric blobs typical of crawler scrape attempts).
+  const ua = (await headers()).get("user-agent") ?? "";
+  const isBot = BOT_UA_REGEX.test(ua);
+  const isGarbage = looksLikeGarbageQuery(query);
+  if (
+    initialThinCount < LOW_RESULT_THRESHOLD &&
+    query.length >= 2 &&
+    !isBot &&
+    !isGarbage
+  ) {
     const rewrites = await rewriteQuery(query);
     if (rewrites.length > 0) {
       for (const rw of rewrites) {


### PR DESCRIPTION
User flagged Vercel log of bingbot hitting /search with garbage query "MuMu_5.0.11_LxoFNKC 32bit" — the request still ran the LLM rewriter (POST api.openai.com/v1/chat/completions, 1.1s, ~0.0015 USD wasted). Bots can hammer the search endpoint and burn OpenAI credits with zero business value.

Two gates added in search/page.tsx before the rewriteQuery call:

1. Bot UA filter — regex matches common crawlers (bingbot, googlebot, claudebot, gptbot, ahrefs, semrush, facebookexternalhit, yandexbot, baiduspider, applebot, amazonbot, etc.). UA pulled via `await headers()` (Next 15 async API).

2. Garbage-query heuristic — checks for:
   - version strings (1.2.3 — installer-shape)
   - file extensions (.exe / .msi / .apk in query)
   - underscored ID-shape tokens (LxoFNKC_32bit, foo_abc123_bar)
   - long alphanumeric blobs (>= 20 chars, no spaces)
   - mixed-case-digit single-token IDs (>= 25 chars, no spaces)

Unit-tested 7/7 garbage queries flagged + 17/17 real queries allowed: allowed examples include 아인슈타인, 한국, met gala, cuban sandwich recipe poster, iPhone 15, GPT-4, React 19, 2024 trends, Y2K aesthetic. Flagged examples include MuMu_5.0.11_LxoFNKC 32bit, installer.exe, setup.msi 64bit.

Behavior change for affected queries: bot or garbage queries now render the empty-result page WITHOUT calling OpenAI. Real users on the same queries are unaffected. Eval regression: 52/54 PASS (no change — eval uses synthetic queries via the CLI, no UA, no garbage).

Notes:
- Bot detection is heuristic, not perfect. Won't catch headless browsers spoofing UAs. Good enough for the common crawler case.
- The garbage heuristic deliberately allows short app names like "MuMu" (just the brand, no version suffix) since a user might legitimately type that. The "_5.0.11_LxoFNKC 32bit" suffix is what triggers the filter.
- Existing rewriter telemetry from commit e8f93ab still fires for real users — bots simply skip the call upstream so no log line.