### PR TITLE
image2image: enable two certain user-photo templates (try-on + abstra…

### DIFF
--- a/public/data/nano_templates.json
+++ b/public/data/nano_templates.json
@@ -5855,7 +5855,9 @@
     "creation_date": "2026-05-03",
     "use_cases": [
       "for-designers"
-    ]
+    ],
+    "requires_image_upload": true,
+    "allow_generation": true
   },
   {
     "id": "template-lifestyle-watercolor-infographic",
@@ -10347,7 +10349,9 @@
     ],
     "rank_score": 106,
     "creation_date": "2026-06-08",
-    "base_rank_score": 90
+    "base_rank_score": 90,
+    "requires_image_upload": true,
+    "allow_generation": true
   },
   {
     "id": "template-crafting-step-by-step-tutorial-infographic",


### PR DESCRIPTION
…ct portrait)

Tooling & Engineering / image2image track. Both prompts explicitly consume the user's OWN portrait (clean — no third-party IP/celebrity likeness), were not generatable before (allow_generation absent → purely additive, no UX change), and have example inspirations (5 / 4):
- template-ai-outfit-try-on-poster ("original reference character portrait")
- template-figure-to-abstract-portrait-series ("original reference photograph")

Set requires_image_upload + allow_generation; the shipped image2image FE upload flow + BE reference handling (561080d) already cover requires_image_upload templates, so this is data-only.

Deliberately NOT enabled: character/IP + real-figure templates (WC players, celebrities, anime) — rights/policy + Gemini refusal risk — and the image-OPTIONAL (text-or-upload) set, both documented + parked. A prompt scan for "reference image" over-matches (53 hits, mostly loose usage) — needs human categorization, confirmed here.