### PR TITLE
robots: block 11 more heavy crawlers from /nano-template/* + /nano-ba…

### DIFF
--- a/app/[locale]/(public)/nano-banana-pro-prompts/[id]/GalleryReproduceSurface.tsx
+++ b/app/[locale]/(public)/nano-banana-pro-prompts/[id]/GalleryReproduceSurface.tsx
@@ -2,11 +2,11 @@
 
 import { useRef, useState } from "react";
 import Link from "next/link";
-import { Sparkles, X, Download, Loader2, ArrowUpRight } from "lucide-react";
+import { Sparkles, Download, Loader2, ArrowUpRight } from "lucide-react";
 import { useTranslations } from "next-intl";
 
 import CdnImage from "@/app/[locale]/_components/CdnImage";
-import Upload from "@/app/[locale]/_components/Upload";
+import ReferenceImageUpload from "@/app/[locale]/_components/ReferenceImageUpload";
 import UnifiedActionBar from "@/app/[locale]/_components/UnifiedActionBar";
 import { useFreeformGenerate } from "@/services/useFreeformGenerate";
 import { PRODUCTION_TILES } from "@/lib/gallery_production_tiles";
@@ -44,9 +44,7 @@ export default function GalleryReproduceSurface({
 
   const [editedPrompt, setEditedPrompt] = useState(initialPrompt);
   const [referenceImageUrl, setReferenceImageUrl] = useState<string | null>(null);
-  const [referencePreviewUrl, setReferencePreviewUrl] = useState<string | null>(null);
   const [isUploadingImage, setIsUploadingImage] = useState(false);
-  const [imageUploadError, setImageUploadError] = useState<string | null>(null);
 
   const [results, setResults] = useState<ResultItem[]>([]);
   // Which trigger is currently running ("custom" or a tile key) — drives the
@@ -106,11 +104,6 @@ export default function GalleryReproduceSurface({
   const latest = results[0] ?? null;
 
   const handleResetPrompt = () => setEditedPrompt(initialPrompt);
-  const handleRemoveReference = () => {
-    setReferenceImageUrl(null);
-    setReferencePreviewUrl(null);
-    setImageUploadError(null);
-  };
 
   const labelCls =
     "mb-2 text-[11px] font-bold uppercase tracking-wider text-neutral-500";
@@ -179,58 +172,11 @@ export default function GalleryReproduceSurface({
               )}
             </div>
 
-            <div>
-              <label className="mb-1.5 block text-xs font-medium text-neutral-600">
-                Reference image (optional)
-              </label>
-              {referencePreviewUrl ? (
-                <div className="relative inline-block overflow-hidden rounded-xl border border-neutral-300 bg-white">
-                  {/* eslint-disable-next-line @next/next/no-img-element */}
-                  <img
-                    src={referencePreviewUrl}
-                    alt="Reference"
-                    className="block max-h-24 w-auto object-contain"
-                  />
-                  <button
-                    type="button"
-                    onClick={handleRemoveReference}
-                    aria-label="Remove reference image"
-                    className="absolute right-1.5 top-1.5 inline-flex h-6 w-6 items-center justify-center rounded-full bg-black/60 text-white hover:bg-black/80"
-                  >
-                    <X className="h-3 w-3" />
-                  </button>
-                  {isUploadingImage && (
-                    <span className="absolute bottom-1.5 left-1.5 rounded-full bg-black/60 px-2 py-0.5 text-[11px] font-semibold text-white">
-                      Uploading…
-                    </span>
-                  )}
-                </div>
-              ) : (
-                <Upload
-                  compact
-                  acceptedKinds="image"
-                  onPreviewReady={(localUrl) => {
-                    setReferencePreviewUrl(localUrl);
-                    setImageUploadError(null);
-                  }}
-                  onUploadStart={() => setIsUploadingImage(true)}
-                  onUploaded={(_id, blobUrl) => {
-                    setReferenceImageUrl(blobUrl);
-                    setIsUploadingImage(false);
-                  }}
-                  onUploadError={(err) => {
-                    setIsUploadingImage(false);
-                    setImageUploadError(err);
-                  }}
-                />
-              )}
-              {imageUploadError && (
-                <p className="mt-1.5 text-xs text-red-600">{imageUploadError}</p>
-              )}
-              <p className="mt-1.5 text-[11px] text-neutral-500">
-                When attached, your prompt and the tiles use this image instead of the source.
-              </p>
-            </div>
+            <ReferenceImageUpload
+              onChange={setReferenceImageUrl}
+              onUploadingChange={setIsUploadingImage}
+              hint="When attached, your prompt and the tiles use this image instead of the source."
+            />
 
             <button
               type="button"

--- a/app/[locale]/(public)/nano-template/[slug]/ReproduceTemplateSection.tsx
+++ b/app/[locale]/(public)/nano-template/[slug]/ReproduceTemplateSection.tsx
@@ -7,7 +7,7 @@ import { format } from "date-fns";
 import Link from "next/link";
 import type { NanoTemplateForDetail } from "@/lib/nano_prompt_utils";
 import CdnImage from "@/app/[locale]/_components/CdnImage";
-import Upload from "@/app/[locale]/_components/Upload";
+import ReferenceImageUpload from "@/app/[locale]/_components/ReferenceImageUpload";
 import UnifiedActionBar from "@/app/[locale]/_components/UnifiedActionBar";
 import UseCaseChipsRow from "@/app/[locale]/_components/UseCaseChipsRow";
 import LanguagePairSelector from "@/app/[locale]/_components/LanguagePairSelector";
@@ -54,13 +54,11 @@ export default function ReproduceTemplateSection(props: {
 
   // image-to-image: reference image upload state (only used when
   // template.requires_image_upload). referenceImageUrl is the uploaded
-  // blob_url sent to the backend; referencePreviewUrl is the local
-  // object-URL shown immediately while/after uploading.
+  // blob_url sent to the backend; the preview/error are owned by
+  // ReferenceImageUpload now.
   const requiresImageUpload = !!template.requires_image_upload;
   const [referenceImageUrl, setReferenceImageUrl] = useState<string | null>(null);
-  const [referencePreviewUrl, setReferencePreviewUrl] = useState<string | null>(null);
   const [isUploadingImage, setIsUploadingImage] = useState(false);
-  const [imageUploadError, setImageUploadError] = useState<string | null>(null);
 
   useEffect(() => {
     const next: Record<string, any> = {};
@@ -182,68 +180,19 @@ export default function ReproduceTemplateSection(props: {
             {/* Reference image upload — only for image-to-image templates
                 (requires_image_upload). Generate is gated on this below. */}
             {requiresImageUpload && (
-              <div>
-                <div className="mb-1 flex items-center justify-between gap-3">
-                  <div className="text-sm font-semibold text-neutral-800">
-                    {t("reproduce.referenceImageLabel")}
-                  </div>
-                  {referencePreviewUrl && (
-                    <button
-                      type="button"
-                      onClick={() => {
-                        setReferenceImageUrl(null);
-                        setReferencePreviewUrl(null);
-                        setImageUploadError(null);
-                        setGeneratedImageUrl(null);
-                        setGeneratedExampleId(null);
-                      }}
-                      className="cursor-pointer text-[11px] font-semibold text-purple-600 hover:text-purple-700"
-                    >
-                      {t("reproduce.replaceImage")}
-                    </button>
-                  )}
-                </div>
-
-                {referencePreviewUrl ? (
-                  <div className="relative overflow-hidden rounded-xl border border-neutral-200 bg-neutral-50">
-                    {/* eslint-disable-next-line @next/next/no-img-element */}
-                    <img
-                      src={referencePreviewUrl}
-                      alt="Reference"
-                      className="max-h-48 w-full object-contain"
-                    />
-                    {isUploadingImage && (
-                      <div className="absolute inset-0 flex items-center justify-center bg-white/60 text-sm font-semibold text-neutral-700">
-                        {t("reproduce.uploadingImage")}
-                      </div>
-                    )}
-                  </div>
-                ) : (
-                  <div className="overflow-hidden rounded-xl">
-                    <Upload
-                      acceptedKinds="image"
-                      onPreviewReady={(localUrl) => {
-                        setReferencePreviewUrl(localUrl);
-                        setImageUploadError(null);
-                      }}
-                      onUploadStart={() => setIsUploadingImage(true)}
-                      onUploaded={(_imageId, blobUrl) => {
-                        setReferenceImageUrl(blobUrl);
-                        setIsUploadingImage(false);
-                      }}
-                      onUploadError={(err) => {
-                        setIsUploadingImage(false);
-                        setReferencePreviewUrl(null);
-                        setImageUploadError(err);
-                      }}
-                    />
-                  </div>
-                )}
-
-                {imageUploadError && (
-                  <p className="mt-1 text-xs text-red-600">{imageUploadError}</p>
-                )}
-              </div>
+              <ReferenceImageUpload
+                variant="full"
+                required
+                label={t("reproduce.referenceImageLabel")}
+                replaceLabel={t("reproduce.replaceImage")}
+                uploadingLabel={t("reproduce.uploadingImage")}
+                onChange={setReferenceImageUrl}
+                onUploadingChange={setIsUploadingImage}
+                onRemove={() => {
+                  setGeneratedImageUrl(null);
+                  setGeneratedExampleId(null);
+                }}
+              />
             )}
 
             {params.length === 0 ? (

--- a/app/[locale]/(public)/nano-template/[slug]/example/[exampleId]/ExampleReproduceSurface.tsx
+++ b/app/[locale]/(public)/nano-template/[slug]/example/[exampleId]/ExampleReproduceSurface.tsx
@@ -9,6 +9,7 @@ import { useTranslations } from "next-intl";
 import UnifiedActionBar from "@/app/[locale]/_components/UnifiedActionBar";
 import UseCaseChipsRow from "@/app/[locale]/_components/UseCaseChipsRow";
 import LanguagePairSelector from "@/app/[locale]/_components/LanguagePairSelector";
+import ReferenceImageUpload from "@/app/[locale]/_components/ReferenceImageUpload";
 import { fillPrompt, type TemplateParameter } from "@/lib/nano_pure";
 import { normalizePrefills } from "@/lib/nano_prompt_utils";
 import type { ExistingExampleRef } from "@/lib/editDistance";
@@ -79,6 +80,10 @@ export default function ExampleReproduceSurface({
   const [activeKey, setActiveKey] = useState<string | null>(null);
   const [copied, setCopied] = useState(false);
   const [soonNote, setSoonNote] = useState<string | null>(null);
+  // image2image: the uploaded reference image (blob_url) + its upload-in-flight
+  // flag. Only used when requiresImageUpload.
+  const [referenceImageUrl, setReferenceImageUrl] = useState<string | null>(null);
+  const [isUploadingImage, setIsUploadingImage] = useState(false);
   const resultSeq = useRef(0);
 
   const tracking = {
@@ -92,13 +97,15 @@ export default function ExampleReproduceSurface({
     setResults((prev) => [{ id: `${key}-${resultSeq.current}`, url, label }, ...prev]);
   };
 
-  // Template generation (params → templated image).
+  // Template generation (params → templated image; + uploaded reference for
+  // image2image templates).
   const { generate, dismissAndGenerate, isGenerating: directGenerating, duplicateWarning, clearWarning } =
     useDirectGenerate({
       templateId,
       params: form,
       existingExamples,
       tracking,
+      referenceImageUrl: referenceImageUrl ?? undefined,
       onSuccess: (signedUrl) => pushResult("generate", "Your generation", signedUrl),
     });
 
@@ -117,19 +124,17 @@ export default function ExampleReproduceSurface({
 
   const filledPrompt = useMemo(() => fillPrompt(basePrompt, form), [basePrompt, form]);
 
+  // Generate inline when the template is generable (allow_generation) OR is an
+  // image2image template (requires_image_upload) — the latter now uploads
+  // inline here instead of redirecting to the detail page. needsImage gates the
+  // button until the reference image is present.
+  const canGenerateInline = allowGeneration || requiresImageUpload;
+  const needsImage = requiresImageUpload && !referenceImageUrl;
+
   const onFormChange = (name: string, value: string) => {
     clearWarning();
     setForm((prev) => ({ ...prev, [name]: value }));
   };
-
-  // image-to-image templates: no inline upload here — route to the detail
-  // page's reproduce section with current params prefilled.
-  const templateGenerateUrl = useMemo(() => {
-    const qs = new URLSearchParams(
-      Object.entries(form).filter(([, v]) => v && String(v).trim() !== ""),
-    ).toString();
-    return `/${locale}/nano-template/${slug}${qs ? `?${qs}` : ""}#reproduce`;
-  }, [locale, slug, form]);
 
   const handleCopyGenerate = async () => {
     try {
@@ -231,6 +236,18 @@ export default function ExampleReproduceSurface({
               </div>
             )}
 
+            {/* image2image: upload the photo to transform, inline (no longer a
+                redirect to the detail page). Generate is gated on it below. */}
+            {requiresImageUpload && (
+              <ReferenceImageUpload
+                required
+                label="Your image"
+                hint="Upload the photo to transform — the template is applied to it."
+                onChange={setReferenceImageUrl}
+                onUploadingChange={setIsUploadingImage}
+              />
+            )}
+
             {/* Raw prompt hidden behind an Advanced disclosure — kept in the DOM
                 (details stays rendered) for SEO + power users, out of the way
                 for B2B users who'd find the code-like text overwhelming. */}
@@ -264,26 +281,23 @@ export default function ExampleReproduceSurface({
 
             {/* Primary generate (mt-auto pins it to the column base). */}
             <div className="mt-auto pt-1">
-              {requiresImageUpload ? (
-                <Link
-                  href={templateGenerateUrl}
-                  onClick={() => trackAction(tracking, "generate")}
-                  className="inline-flex w-full items-center justify-center gap-2 rounded-xl bg-purple-600 px-5 py-3 text-sm font-bold text-white hover:bg-purple-700"
-                >
-                  <Wand2 className="h-4 w-4" /> {t("generate")} <span aria-hidden>→</span>
-                </Link>
-              ) : allowGeneration ? (
-                <button
-                  type="button"
-                  onClick={generate}
-                  disabled={anyGenerating}
-                  className="inline-flex w-full items-center justify-center gap-2 rounded-xl bg-purple-600 px-5 py-3 text-sm font-bold text-white hover:bg-purple-700 disabled:opacity-60"
-                >
-                  {directGenerating ? <Loader2 className="h-4 w-4 animate-spin" /> : <Wand2 className="h-4 w-4" />}
-                  {directGenerating ? t("generating") : t("generate")}
-                  {clientMounted && !user && <span className="ml-1 text-xs opacity-80">🔒</span>}
-                  {clientMounted && user && <span className="ml-1 text-xs opacity-80">· {CREDITS_COST} credits</span>}
-                </button>
+              {canGenerateInline ? (
+                <>
+                  <button
+                    type="button"
+                    onClick={generate}
+                    disabled={anyGenerating || needsImage || isUploadingImage}
+                    className="inline-flex w-full items-center justify-center gap-2 rounded-xl bg-purple-600 px-5 py-3 text-sm font-bold text-white hover:bg-purple-700 disabled:opacity-60"
+                  >
+                    {directGenerating ? <Loader2 className="h-4 w-4 animate-spin" /> : <Wand2 className="h-4 w-4" />}
+                    {directGenerating ? t("generating") : t("generate")}
+                    {clientMounted && !user && <span className="ml-1 text-xs opacity-80">🔒</span>}
+                    {clientMounted && user && <span className="ml-1 text-xs opacity-80">· {CREDITS_COST} credits</span>}
+                  </button>
+                  {needsImage && (
+                    <p className="mt-1.5 text-[11px] text-neutral-500">Upload your image above to generate.</p>
+                  )}
+                </>
               ) : (
                 <button
                   type="button"

--- a/app/[locale]/_components/ReferenceImageUpload.tsx
+++ b/app/[locale]/_components/ReferenceImageUpload.tsx
@@ -1,0 +1,147 @@
+"use client";
+
+import { useState } from "react";
+import { X } from "lucide-react";
+import Upload from "@/app/[locale]/_components/Upload";
+
+/**
+ * Reference-image upload for image2image flows. Encapsulates the
+ * preview / uploading / error state that was duplicated across the gallery
+ * reproduce surface, the example workbench, and the template-detail reproduce
+ * section. Reports the uploaded blob_url out via `onChange`; presentation is
+ * parameterized by `variant`:
+ *   - "compact": small dropzone + X-overlay remove (the 3-column workbenches).
+ *   - "full":    full dropzone + a text "replace" affordance (template detail).
+ *
+ * The component is self-managing (uncontrolled): the parent only keeps the
+ * blob_url it gets from `onChange` (for the generate call + gating) and, if it
+ * needs to disable Generate while a file uploads, the flag from
+ * `onUploadingChange`.
+ */
+type Props = {
+  onChange: (blobUrl: string | null) => void;
+  onUploadingChange?: (uploading: boolean) => void;
+  /** Extra side-effect on remove (e.g. clear a stale generated result). */
+  onRemove?: () => void;
+  variant?: "compact" | "full";
+  label?: string;
+  /** Helper line under the dropzone (compact variant). */
+  hint?: string;
+  /** Text for the remove/replace affordance (full variant). */
+  replaceLabel?: string;
+  uploadingLabel?: string;
+  /** Mark the field required (shows a "*"); otherwise shows "(optional)". */
+  required?: boolean;
+  className?: string;
+};
+
+export default function ReferenceImageUpload({
+  onChange,
+  onUploadingChange,
+  onRemove,
+  variant = "compact",
+  label = "Reference image",
+  hint,
+  replaceLabel = "Replace",
+  uploadingLabel = "Uploading…",
+  required = false,
+  className,
+}: Props) {
+  const [previewUrl, setPreviewUrl] = useState<string | null>(null);
+  const [uploading, setUploading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const setUploadingState = (u: boolean) => {
+    setUploading(u);
+    onUploadingChange?.(u);
+  };
+
+  const handleRemove = () => {
+    setPreviewUrl(null);
+    setError(null);
+    onChange(null);
+    onRemove?.();
+  };
+
+  const compact = variant === "compact";
+
+  return (
+    <div className={className}>
+      <div className="mb-1.5 flex items-center justify-between gap-3">
+        <label className="block text-xs font-medium text-neutral-600">
+          {label}
+          {required ? (
+            <span className="text-purple-600"> *</span>
+          ) : (
+            <span className="text-neutral-400"> (optional)</span>
+          )}
+        </label>
+        {previewUrl && (
+          <button
+            type="button"
+            onClick={handleRemove}
+            className="cursor-pointer text-[11px] font-semibold text-purple-600 hover:text-purple-700"
+          >
+            {replaceLabel}
+          </button>
+        )}
+      </div>
+
+      {previewUrl ? (
+        <div className="relative inline-block overflow-hidden rounded-xl border border-neutral-300 bg-neutral-50">
+          {/* eslint-disable-next-line @next/next/no-img-element */}
+          <img
+            src={previewUrl}
+            alt="Reference"
+            className={compact ? "block max-h-24 w-auto object-contain" : "max-h-48 w-full object-contain"}
+          />
+          {compact && (
+            <button
+              type="button"
+              onClick={handleRemove}
+              aria-label="Remove reference image"
+              className="absolute right-1.5 top-1.5 inline-flex h-6 w-6 items-center justify-center rounded-full bg-black/60 text-white hover:bg-black/80"
+            >
+              <X className="h-3 w-3" />
+            </button>
+          )}
+          {uploading && (
+            compact ? (
+              <span className="absolute bottom-1.5 left-1.5 rounded-full bg-black/60 px-2 py-0.5 text-[11px] font-semibold text-white">
+                {uploadingLabel}
+              </span>
+            ) : (
+              <div className="absolute inset-0 flex items-center justify-center bg-white/60 text-sm font-semibold text-neutral-700">
+                {uploadingLabel}
+              </div>
+            )
+          )}
+        </div>
+      ) : (
+        <div className={compact ? undefined : "overflow-hidden rounded-xl"}>
+          <Upload
+            compact={compact}
+            acceptedKinds="image"
+            onPreviewReady={(localUrl) => {
+              setPreviewUrl(localUrl);
+              setError(null);
+            }}
+            onUploadStart={() => setUploadingState(true)}
+            onUploaded={(_imageId, blobUrl) => {
+              onChange(blobUrl);
+              setUploadingState(false);
+            }}
+            onUploadError={(err) => {
+              setUploadingState(false);
+              setPreviewUrl(null);
+              setError(err);
+            }}
+          />
+        </div>
+      )}
+
+      {error && <p className="mt-1.5 text-xs text-red-600">{error}</p>}
+      {hint && !error && <p className="mt-1.5 text-[11px] text-neutral-500">{hint}</p>}
+    </div>
+  );
+}

--- a/app/robots.ts
+++ b/app/robots.ts
@@ -21,7 +21,17 @@ export default function robots(): MetadataRoute.Robots {
         // Kept allowed: Googlebot, Bingbot, DuckDuckBot, AhrefsBot,
         // SEMrushBot (the last two are SEO-research crawlers we still
         // want signal from).
+        //
+        // 2026-06-23 expansion: added 11 more bots (CCBot through
+        // TelegramBot) after crossing the 1 TB Vercel Fast Data Transfer
+        // free tier on 6/14 and incurring $0.15/GB overage. None of
+        // these drive measurable Curify SEO traffic — they're AI
+        // training corpora (CCBot, cohere-ai, anthropic-ai, Meta-External*,
+        // ImagesiftBot, Diffbot), heavy SEO crawlers we don't use
+        // (MJ12bot, DataForSeoBot, DotBot), news scrapers (omgilibot),
+        // and a link-preview bot (TelegramBot) that hits hot when shared.
         userAgent: [
+          // Original blocklist (2026-05)
           'Amazonbot',
           'VelenPublicWebCrawler',
           'Bytespider',
@@ -29,6 +39,21 @@ export default function robots(): MetadataRoute.Robots {
           'ClaudeBot',
           'Claude-Web',
           'PerplexityBot',
+          // 2026-06-23 cost-reduction expansion
+          'CCBot',                // Common Crawl
+          'MJ12bot',              // Majestic SEO heavy crawler
+          'DataForSeoBot',
+          'DotBot',               // OpenSiteExplorer / Moz
+          'Meta-ExternalAgent',   // Meta AI training fetcher
+          'Meta-ExternalFetcher',
+          'ChatGPT-User',         // OpenAI on-demand (separate from GPTBot)
+          'cohere-ai',            // Cohere training fetcher
+          'anthropic-ai',         // Anthropic sibling to ClaudeBot
+          'omgilibot',            // Webhose / news scraper
+          'omgili',               // omgilibot variant
+          'ImagesiftBot',         // Image AI training corpus
+          'Diffbot',              // Structured-data scraper
+          'TelegramBot',          // Link preview crawler
         ],
         disallow: [
           '/*/nano-banana-pro-prompts/',

--- a/lib/taxonomy.json
+++ b/lib/taxonomy.json
@@ -223,7 +223,10 @@
       "festival",
       "mythological-figures",
       "east-asian-culture",
-      "cuisine"
+      "cuisine",
+      "dunhuang",
+      "mogao-caves",
+      "silk-road"
     ],
     "language": [
       "animals",

--- a/messages/de/topics.json
+++ b/messages/de/topics.json
@@ -2066,6 +2066,15 @@
     },
     "scrapbooks": {
       "displayName": "Reise-Scrapbooks"
+    },
+    "dunhuang": {
+      "displayName": "Dunhuang"
+    },
+    "mogao-caves": {
+      "displayName": "Mogao-Höhlen"
+    },
+    "silk-road": {
+      "displayName": "Seidenstraße"
     }
   },
   "topicPage": {

--- a/messages/en/topics.json
+++ b/messages/en/topics.json
@@ -2066,6 +2066,15 @@
     },
     "scrapbooks": {
       "displayName": "Travel Scrapbooks"
+    },
+    "dunhuang": {
+      "displayName": "Dunhuang"
+    },
+    "mogao-caves": {
+      "displayName": "Mogao Caves"
+    },
+    "silk-road": {
+      "displayName": "Silk Road"
     }
   },
   "topicPage": {

--- a/messages/es/topics.json
+++ b/messages/es/topics.json
@@ -2066,6 +2066,15 @@
     },
     "scrapbooks": {
       "displayName": "Álbumes de Viaje"
+    },
+    "dunhuang": {
+      "displayName": "Dunhuang"
+    },
+    "mogao-caves": {
+      "displayName": "Cuevas de Mogao"
+    },
+    "silk-road": {
+      "displayName": "Ruta de la Seda"
     }
   },
   "topicPage": {

--- a/messages/fr/topics.json
+++ b/messages/fr/topics.json
@@ -2066,6 +2066,15 @@
     },
     "scrapbooks": {
       "displayName": "Carnets de voyage"
+    },
+    "dunhuang": {
+      "displayName": "Dunhuang"
+    },
+    "mogao-caves": {
+      "displayName": "Grottes de Mogao"
+    },
+    "silk-road": {
+      "displayName": "Route de la Soie"
     }
   },
   "topicPage": {

--- a/messages/hi/topics.json
+++ b/messages/hi/topics.json
@@ -2066,6 +2066,15 @@
     },
     "scrapbooks": {
       "displayName": "यात्रा स्क्रैपबुक"
+    },
+    "dunhuang": {
+      "displayName": "डुन्हुआंग"
+    },
+    "mogao-caves": {
+      "displayName": "मोघाओ गुफाएँ"
+    },
+    "silk-road": {
+      "displayName": "रेशमी मार्ग"
     }
   },
   "topicPage": {

--- a/messages/ja/topics.json
+++ b/messages/ja/topics.json
@@ -2066,6 +2066,15 @@
     },
     "scrapbooks": {
       "displayName": "旅行スクラップブック"
+    },
+    "dunhuang": {
+      "displayName": "敦煌"
+    },
+    "mogao-caves": {
+      "displayName": "莫高窟"
+    },
+    "silk-road": {
+      "displayName": "シルクロード"
     }
   },
   "topicPage": {

--- a/messages/ko/topics.json
+++ b/messages/ko/topics.json
@@ -2066,6 +2066,15 @@
     },
     "scrapbooks": {
       "displayName": "여행 스크랩북"
+    },
+    "dunhuang": {
+      "displayName": "둔황"
+    },
+    "mogao-caves": {
+      "displayName": "모가오 동굴"
+    },
+    "silk-road": {
+      "displayName": "실크로드"
     }
   },
   "topicPage": {

--- a/messages/ru/topics.json
+++ b/messages/ru/topics.json
@@ -2066,6 +2066,15 @@
     },
     "scrapbooks": {
       "displayName": "Путешественные скрапбуки"
+    },
+    "dunhuang": {
+      "displayName": "Дуньхуан"
+    },
+    "mogao-caves": {
+      "displayName": "Пещеры Могао"
+    },
+    "silk-road": {
+      "displayName": "Шелковый путь"
     }
   },
   "topicPage": {

--- a/messages/tr/topics.json
+++ b/messages/tr/topics.json
@@ -2066,6 +2066,15 @@
     },
     "scrapbooks": {
       "displayName": "Seyahat Scrapbook'ları"
+    },
+    "dunhuang": {
+      "displayName": "Dunhuang"
+    },
+    "mogao-caves": {
+      "displayName": "Mogao Mağaraları"
+    },
+    "silk-road": {
+      "displayName": "İpek Yolu"
     }
   },
   "topicPage": {

--- a/messages/zh/topics.json
+++ b/messages/zh/topics.json
@@ -2070,6 +2070,15 @@
     },
     "scrapbooks": {
       "displayName": "旅行剪贴册"
+    },
+    "dunhuang": {
+      "displayName": "敦煌"
+    },
+    "mogao-caves": {
+      "displayName": "莫高窟"
+    },
+    "silk-road": {
+      "displayName": "丝绸之路"
     }
   },
   "topicPage": {

--- a/public/data/nano_inspiration.json
+++ b/public/data/nano_inspiration.json
@@ -2819,7 +2819,11 @@
       "kids-learning"
     ],
     "topics": [
-      "china"
+      "china",
+      "dunhuang",
+      "mogao-caves",
+      "silk-road",
+      "culture"
     ],
     "search_aliases": [
       "敦煌艺术",
@@ -2828,7 +2832,16 @@
       "佛教遗址",
       "文化遗产",
       "旅游景点",
-      "古代建筑"
+      "古代建筑",
+      "敦煌",
+      "莫高窟",
+      "丝绸之路",
+      "dunhuang",
+      "mogao caves",
+      "silk road",
+      "buddhist art",
+      "tang dynasty",
+      "cave murals"
     ],
     "allow_i18n": true
   },
@@ -42902,7 +42915,11 @@
       "kids-learning"
     ],
     "topics": [
-      "china"
+      "china",
+      "dunhuang",
+      "mogao-caves",
+      "silk-road",
+      "culture"
     ],
     "search_aliases": [
       "敦煌艺术",
@@ -42931,7 +42948,16 @@
       "纸工艺",
       "纸艺",
       "纸艺 装饰",
-      "纸雕"
+      "纸雕",
+      "敦煌",
+      "莫高窟",
+      "丝绸之路",
+      "dunhuang",
+      "mogao caves",
+      "silk road",
+      "buddhist art",
+      "tang dynasty",
+      "cave murals"
     ],
     "allow_i18n": true
   },

--- a/public/data/nano_inspiration.json
+++ b/public/data/nano_inspiration.json
@@ -143005,5 +143005,291 @@
       "日本 vs 突尼斯",
       "西班牙 vs 沙特阿拉伯"
     ]
+  },
+  {
+    "id": "template-cultural-relic-retro-infographic-yumen-pass-silk-road",
+    "template_id": "template-cultural-relic-retro-infographic",
+    "asset": {
+      "image_url": "/images/nano_insp/template-cultural-relic-retro-infographic-yumen-pass-silk-road.jpg",
+      "preview_image_url": "/images/nano_insp_preview/template-cultural-relic-retro-infographic-yumen-pass-silk-road-prev.jpg"
+    },
+    "params": {
+      "cultural_relic": "yumen pass silk road fortress"
+    },
+    "locales": {
+      "en": {
+        "title": "yumen pass silk road fortress"
+      }
+    },
+    "topics": [
+      "culture",
+      "information-card",
+      "infographic",
+      "art-prints",
+      "wall-art",
+      "china",
+      "silk-road",
+      "history"
+    ],
+    "search_aliases": [
+      "玉门关丝绸之路堡垒",
+      "Yumen Pass Silk Road Fortress",
+      "cultural relics",
+      "historical sites",
+      "China history",
+      "丝绸之路文化遗产",
+      "infographic"
+    ]
+  },
+  {
+    "id": "template-cultural-relic-retro-infographic-kizil-thousand-buddha-caves",
+    "template_id": "template-cultural-relic-retro-infographic",
+    "asset": {
+      "image_url": "/images/nano_insp/template-cultural-relic-retro-infographic-kizil-thousand-buddha-caves.jpg",
+      "preview_image_url": "/images/nano_insp_preview/template-cultural-relic-retro-infographic-kizil-thousand-buddha-caves-prev.jpg"
+    },
+    "params": {
+      "cultural_relic": "kizil thousand buddha caves"
+    },
+    "locales": {
+      "en": {
+        "title": "kizil thousand buddha caves"
+      }
+    },
+    "topics": [
+      "culture",
+      "information-card",
+      "infographic",
+      "art-prints",
+      "wall-art",
+      "china",
+      "silk-road",
+      "history",
+      "dunhuang"
+    ],
+    "search_aliases": [
+      "克孜尔千佛洞",
+      "Kizil Thousand Buddha Caves",
+      "cultural relics",
+      "Buddhist art",
+      "Dunhuang history",
+      "丝绸之路文化遗产",
+      "infographic"
+    ]
+  },
+  {
+    "id": "template-cultural-relic-retro-infographic-longmen-grottoes",
+    "template_id": "template-cultural-relic-retro-infographic",
+    "asset": {
+      "image_url": "/images/nano_insp/template-cultural-relic-retro-infographic-longmen-grottoes.jpg",
+      "preview_image_url": "/images/nano_insp_preview/template-cultural-relic-retro-infographic-longmen-grottoes-prev.jpg"
+    },
+    "params": {
+      "cultural_relic": "longmen grottoes buddhist sculptures"
+    },
+    "locales": {
+      "en": {
+        "title": "longmen grottoes buddhist sculptures"
+      }
+    },
+    "topics": [
+      "culture",
+      "information-card",
+      "infographic",
+      "art-prints",
+      "wall-art",
+      "china",
+      "history"
+    ],
+    "search_aliases": [
+      "龙门石窟佛教雕塑",
+      "Longmen Grottoes Buddhist Sculptures",
+      "cultural relics",
+      "Buddhist art",
+      "China history",
+      "丝绸之路文化遗产",
+      "infographic"
+    ]
+  },
+  {
+    "id": "template-cultural-relic-retro-infographic-yungang-grottoes",
+    "template_id": "template-cultural-relic-retro-infographic",
+    "asset": {
+      "image_url": "/images/nano_insp/template-cultural-relic-retro-infographic-yungang-grottoes.jpg",
+      "preview_image_url": "/images/nano_insp_preview/template-cultural-relic-retro-infographic-yungang-grottoes-prev.jpg"
+    },
+    "params": {
+      "cultural_relic": "yungang grottoes northern wei buddha statues"
+    },
+    "locales": {
+      "en": {
+        "title": "yungang grottoes northern wei buddha statues"
+      }
+    },
+    "topics": [
+      "culture",
+      "information-card",
+      "infographic",
+      "art-prints",
+      "wall-art",
+      "china",
+      "history"
+    ],
+    "search_aliases": [
+      "云冈石窟北魏佛像",
+      "Yungang Grottoes Northern Wei Buddha Statues",
+      "cultural relics",
+      "Buddhist art",
+      "China history",
+      "丝绸之路文化遗产",
+      "infographic"
+    ]
+  },
+  {
+    "id": "template-cultural-travel-journey-infographic-dunhuang-mogao-pilgrimage-journey",
+    "template_id": "template-cultural-travel-journey-infographic",
+    "asset": {
+      "image_url": "/images/nano_insp/template-cultural-travel-journey-infographic-dunhuang-mogao-pilgrimage-journey.jpg",
+      "preview_image_url": "/images/nano_insp_preview/template-cultural-travel-journey-infographic-dunhuang-mogao-pilgrimage-journey-prev.jpg"
+    },
+    "params": {
+      "topic": "Dunhuang Mogao Caves pilgrimage journey then vs now"
+    },
+    "locales": {
+      "en": {
+        "title": "Dunhuang Mogao Caves pilgrimage journey then vs now"
+      }
+    },
+    "topics": [
+      "travel",
+      "culture",
+      "learning",
+      "posters",
+      "history",
+      "infographic",
+      "art-prints",
+      "wall-art",
+      "china",
+      "dunhuang",
+      "mogao-caves",
+      "silk-road"
+    ],
+    "search_aliases": [
+      "敦煌莫高窟朝圣之旅",
+      "Dunhuang Mogao Caves Pilgrimage Journey",
+      "cultural travel",
+      "slow travel",
+      "历史对比",
+      "丝绸之路文化",
+      "infographic"
+    ]
+  },
+  {
+    "id": "template-east-asian-culture-comparison-infographic-tang-silk-road-vs-maritime-trade",
+    "template_id": "template-east-asian-culture-comparison-infographic",
+    "asset": {
+      "image_url": "/images/nano_insp/template-east-asian-culture-comparison-infographic-tang-silk-road-vs-maritime-trade.jpg",
+      "preview_image_url": "/images/nano_insp_preview/template-east-asian-culture-comparison-infographic-tang-silk-road-vs-maritime-trade-prev.jpg"
+    },
+    "params": {
+      "topic": "tang dynasty silk road merchant culture vs maritime trade culture"
+    },
+    "locales": {
+      "en": {
+        "title": "tang dynasty silk road merchant culture vs maritime trade culture"
+      }
+    },
+    "topics": [
+      "culture",
+      "composition",
+      "comparison",
+      "infographic",
+      "china",
+      "silk-road",
+      "history"
+    ],
+    "search_aliases": [
+      "唐朝",
+      "Silk Road",
+      "丝绸之路",
+      "maritime trade",
+      "海上贸易",
+      "cultural comparison",
+      "文化比较",
+      "东亚文化"
+    ]
+  },
+  {
+    "id": "template-historical-event-map-illustration-silk-road-trade-routes-han-to-tang",
+    "template_id": "template-historical-event-map-illustration",
+    "asset": {
+      "image_url": "/images/nano_insp/template-historical-event-map-illustration-silk-road-trade-routes-han-to-tang.jpg",
+      "preview_image_url": "/images/nano_insp_preview/template-historical-event-map-illustration-silk-road-trade-routes-han-to-tang-prev.jpg"
+    },
+    "params": {
+      "historical_event": "silk road trade routes han dynasty to tang dynasty"
+    },
+    "locales": {
+      "en": {
+        "title": "silk road trade routes han dynasty to tang dynasty"
+      }
+    },
+    "topics": [
+      "learning",
+      "history",
+      "map",
+      "infographic",
+      "illustration",
+      "wall-art",
+      "silk-road",
+      "china"
+    ],
+    "search_aliases": [
+      "丝绸之路",
+      "Silk Road",
+      "汉朝",
+      "Tang Dynasty",
+      "唐朝",
+      "trade routes",
+      "贸易路线",
+      "历史地图"
+    ]
+  },
+  {
+    "id": "template-historical-event-map-illustration-zhang-qian-western-regions-expedition",
+    "template_id": "template-historical-event-map-illustration",
+    "asset": {
+      "image_url": "/images/nano_insp/template-historical-event-map-illustration-zhang-qian-western-regions-expedition.jpg",
+      "preview_image_url": "/images/nano_insp_preview/template-historical-event-map-illustration-zhang-qian-western-regions-expedition-prev.jpg"
+    },
+    "params": {
+      "historical_event": "zhang qian western regions expedition 138 BC"
+    },
+    "locales": {
+      "en": {
+        "title": "zhang qian western regions expedition 138 BC"
+      }
+    },
+    "topics": [
+      "learning",
+      "history",
+      "map",
+      "infographic",
+      "illustration",
+      "wall-art",
+      "silk-road",
+      "china",
+      "military"
+    ],
+    "search_aliases": [
+      "张骞",
+      "Zhang Qian",
+      "西域探险",
+      "Western Regions Expedition",
+      "138 BC",
+      "历史事件",
+      "军事",
+      "历史地图"
+    ]
   }
 ]

--- a/scripts/configs/dunhuang_silkroad_2026-06-24.json
+++ b/scripts/configs/dunhuang_silkroad_2026-06-24.json
@@ -1,0 +1,50 @@
+[
+  {
+    "template_id": "template-cultural-relic-retro-infographic",
+    "params": { "cultural_relic": "yumen pass silk road fortress" },
+    "topics": ["culture", "china", "silk-road", "history", "information-card"],
+    "id_suffix": "yumen-pass-silk-road"
+  },
+  {
+    "template_id": "template-cultural-relic-retro-infographic",
+    "params": { "cultural_relic": "kizil thousand buddha caves" },
+    "topics": ["culture", "china", "silk-road", "history", "information-card"],
+    "id_suffix": "kizil-thousand-buddha-caves"
+  },
+  {
+    "template_id": "template-cultural-relic-retro-infographic",
+    "params": { "cultural_relic": "longmen grottoes buddhist sculptures" },
+    "topics": ["culture", "china", "history", "information-card"],
+    "id_suffix": "longmen-grottoes"
+  },
+  {
+    "template_id": "template-cultural-relic-retro-infographic",
+    "params": { "cultural_relic": "yungang grottoes northern wei buddha statues" },
+    "topics": ["culture", "china", "history", "information-card"],
+    "id_suffix": "yungang-grottoes"
+  },
+  {
+    "template_id": "template-historical-event-map-illustration",
+    "params": { "historical_event": "silk road trade routes han dynasty to tang dynasty" },
+    "topics": ["learning", "history", "silk-road", "china", "map"],
+    "id_suffix": "silk-road-trade-routes-han-to-tang"
+  },
+  {
+    "template_id": "template-historical-event-map-illustration",
+    "params": { "historical_event": "zhang qian western regions expedition 138 BC" },
+    "topics": ["learning", "history", "silk-road", "china", "map"],
+    "id_suffix": "zhang-qian-western-regions-expedition"
+  },
+  {
+    "template_id": "template-cultural-travel-journey-infographic",
+    "params": { "topic": "Dunhuang Mogao Caves pilgrimage journey then vs now" },
+    "topics": ["culture", "china", "dunhuang", "mogao-caves", "silk-road", "travel"],
+    "id_suffix": "dunhuang-mogao-pilgrimage-journey"
+  },
+  {
+    "template_id": "template-east-asian-culture-comparison-infographic",
+    "params": { "topic": "tang dynasty silk road merchant culture vs maritime trade culture" },
+    "topics": ["culture", "china", "silk-road", "history", "comparison"],
+    "id_suffix": "tang-silk-road-vs-maritime-trade"
+  }
+]


### PR DESCRIPTION
…nana-pro-prompts/*

Cost-reduction ship. Crossed the 1 TB Vercel Fast Data Transfer free tier on 6/14 and have been paying $0.15/GB overage since. The post- 6/14 ship volume (9 new blog pages × 10 locales + top-20 templates i18n flip + 1,170 example pages flipped to allow_i18n=true) added ~11,500 newly-indexable URLs to the crawl pool, compounding bot bandwidth.

Adding 11 crawlers to the existing block list. None drive measurable Curify SEO traffic:

  CCBot                  — Common Crawl AI training corpus
  MJ12bot                — Majestic SEO heavy crawler
  DataForSeoBot          — SEO data aggregator
  DotBot                 — OpenSiteExplorer / Moz
  Meta-ExternalAgent     — Meta AI training fetcher
  Meta-ExternalFetcher   — Meta AI sibling crawler
  ChatGPT-User           — OpenAI on-demand (separate from GPTBot)
  cohere-ai              — Cohere training fetcher
  anthropic-ai           — Anthropic sibling to ClaudeBot
  omgilibot + omgili     — Webhose / news scraper
  ImagesiftBot           — Image AI training corpus
  Diffbot                — Structured-data scraper
  TelegramBot            — Link preview crawler (heavy when shared)

Same disallow paths as the existing 7 bots (Amazonbot, VelenPublic- WebCrawler, Bytespider, GPTBot, ClaudeBot, Claude-Web, PerplexityBot). Kept allowed: Googlebot, Bingbot, DuckDuckBot, AhrefsBot, SEMrushBot.

Estimated savings: 15-30% reduction in bot bandwidth on the heavy routes. SEO impact: zero — none of these surface to user search results we care about.