### PR TITLE
Search relevance v2 R3 root cause fixes

### DIFF
--- a/app/[locale]/(public)/search/page.tsx
+++ b/app/[locale]/(public)/search/page.tsx
@@ -344,6 +344,23 @@ export default async function SearchPage({ params, searchParams }: Props) {
     }
   >;
   const templateSearchBlob = new Map<string, string>(); // template_id -> blob
+  // Direction 7 / Stage 10 root-cause finding: template-level strict
+  // promotion (below) treats a match ANYWHERE in this blob as equally
+  // strong evidence, including the long free-text `content.sections.what`
+  // "how it works" paragraph. Confirmed live: template-mbti-breakingbad's
+  // sections.what literally contains "periodic table typography" / zh
+  // "元素周期表排版" (a decorative motif description for a Breaking-Bad-
+  // themed MBTI CHARACTER CARD template, unrelated to actual periodic-
+  // table educational content) -- this alone strict-matches "periodic
+  // table" / "元素周期表" and promotes all 20 of that template's character
+  // card inspirations to score=100 strict. templateTitleCategoryBlob
+  // captures ONLY the high-signal category+title fields (no long
+  // description/how-to text) so the Stage 7/9 scorer can tell "matched
+  // via title/category" apart from "matched only via the description
+  // prose" for template-promoted records, without changing WHICH
+  // templates strict-match (that stays as-is to avoid any recall/zero-
+  // result regression -- see 15_BROAD_TEMPLATE_ROOT_CAUSE_ANALYSIS.md).
+  const templateTitleCategoryBlob = new Map<string, string>();
   for (const loc of localesToScan) {
     let entries: NanoTemplateMessages = {};
     try {
@@ -364,6 +381,15 @@ export default async function SearchPage({ params, searchParams }: Props) {
         tid,
         (templateSearchBlob.get(tid) ?? "") + " " + normalizeForSearch(parts.join(" "))
       );
+      const titleCatParts = [e?.category, e?.title].filter(
+        (v): v is string => typeof v === "string" && v.length > 0
+      );
+      if (titleCatParts.length > 0) {
+        templateTitleCategoryBlob.set(
+          tid,
+          (templateTitleCategoryBlob.get(tid) ?? "") + " " + normalizeForSearch(titleCatParts.join(" "))
+        );
+      }
     }
   }
   // Augment the i18n blob with each template's topic slugs so queries
@@ -608,26 +634,59 @@ export default async function SearchPage({ params, searchParams }: Props) {
     for (const r of nanoInspiration as InspRecord[]) {
       if (promoteAllUnderStrictTpl && strictTpl.has(r.template_id)) {
         // Template-level strict promotion: broad-recall path (see doc
-        // comment above). The signal backing this record IS the
-        // template's own blob (title/category/description), so treat
-        // title+tags as present for scoring purposes; check the actual
-        // template blob for exact-phrase evidence rather than assuming.
-        const tplBlob = templateSearchBlob.get(r.template_id) ?? "";
-        let exactPhraseHit = originalProtectedPhrases.some((p) => tplBlob.includes(p));
+        // comment above) -- retrieval/promotion itself is UNCHANGED (an
+        // inspiration is still promoted whenever its template strict-
+        // matches anywhere in the full blob, preserving recall / not
+        // risking a new zero-result case). What changed (Stage 10 root-
+        // cause fix) is the SCORING evidence: previously this branch
+        // hardcoded titleHit/tagsHit/subjectPresent=true unconditionally,
+        // which meant a match buried in the template's long free-text
+        // `content.sections.what` "how it works" prose scored identically
+        // to a match in the title/category. Confirmed live: template-
+        // mbti-breakingbad's sections.what literally contains "periodic
+        // table typography" (a decorative motif description, not
+        // periodic-table content), which strict-matched "periodic table"
+        // / "元素周期表" and promoted all 20 Breaking-Bad character cards
+        // with no scoring penalty at all — see
+        // 15_BROAD_TEMPLATE_ROOT_CAUSE_ANALYSIS.md. Now titleHit /
+        // subjectPresent are evaluated against templateTitleCategoryBlob
+        // (title+category ONLY, no description/how-to text); a match
+        // that only exists in the broader description still promotes the
+        // record (recall preserved) but is correctly scored as weaker
+        // evidence.
+        const tplTitleCatBlob = templateTitleCategoryBlob.get(r.template_id) ?? "";
+        let exactPhraseHit = originalProtectedPhrases.some((p) => tplTitleCatBlob.includes(p));
         if (!exactPhraseHit && originalQueryPhraseText.includes(" ")) {
-          exactPhraseHit = tplBlob.includes(originalQueryPhraseText);
+          exactPhraseHit = tplTitleCatBlob.includes(originalQueryPhraseText);
+        }
+        const titleHit =
+          scoreBlob(tplTitleCatBlob, tokens).allPrimary ||
+          scoreBlob(tplTitleCatBlob, tokens).bigramHits > 0;
+        let subjectPresent: boolean;
+        if (originalProtectedPhrases.length > 0) {
+          const anchors = getAnchorTokens(originalProtectedPhrases);
+          subjectPresent =
+            originalProtectedPhrases.some((p) => tplTitleCatBlob.includes(p)) ||
+            anchors.some((a) => tokenInBlob(tplTitleCatBlob, a));
+        } else if (originalPrimaryTokensForSubject.length <= 1) {
+          subjectPresent = titleHit;
+        } else {
+          const subjectToken = [...originalPrimaryTokensForSubject].sort(
+            (a, b) => b.length - a.length
+          )[0];
+          subjectPresent = tokenInBlob(tplTitleCatBlob, subjectToken);
         }
         scored.push({
           rec: r,
           score: 100,
           strict: true,
           fields: {
-            titleHit: true,
-            tagsHit: true,
+            titleHit,
+            tagsHit: true, // the full blob (tags/topics/description) did strict-match by definition
             paramsOnlyHit: false,
             exactPhraseHit,
             substringOnly: false,
-            subjectPresent: true,
+            subjectPresent,
           },
         });
         continue;

--- a/app/[locale]/(public)/search/page.tsx
+++ b/app/[locale]/(public)/search/page.tsx
@@ -43,6 +43,7 @@ import {
   type ScoredCandidate,
 } from "@/lib/relevanceScorer";
 import { TOTAL_CANDIDATE_POOL_CAP, PATH_CANDIDATE_CAP } from "@/lib/relevanceScorerConfig";
+import { subjectUnits } from "@/lib/searchSubject";
 import SearchResultsClient from "./SearchResultsClient";
 
 // Threshold below which we trigger the LLM multi-query expansion path
@@ -597,26 +598,21 @@ export default async function SearchPage({ params, searchParams }: Props) {
       subjectPresent =
         protectedPhrases.some((p) => combined.includes(p)) ||
         anchors.some((a) => tokenInBlob(combined, a));
-    } else if (originalPrimaryTokens.length <= 1) {
-      // Fix B (2026-07-21, scorer-v1.1 eval Cluster B / 笔袋 flagship): make
-      // single-token subject-presence CONSISTENT with the multi-term branch
-      // below — require the ORIGINAL query's subject token to actually appear
-      // (whole-token for ASCII, substring for CJK) in the title/tags blob, NOT
-      // the `titleHit || tagsHit` shortcut, which is derived from THIS path's
-      // (possibly rewritten/decomposed) callTokens and includes a CJK
-      // bigram/substring fallback. That shortcut let an off-subject non-original
-      // candidate whose only 袋-content was an alias like 帆布袋设计 (canvas tote
-      // bag) read as subject-present for the query 笔袋 — via a decomposition
-      // slot's CJK bigram — and so bypass NON_ORIGINAL_OFFSUBJECT_EXTRA_PENALTY
-      // and the result-rich gate, ranking #1 over genuine stationery (Step-6
-      // residual, confirmed live). Uses originalPrimaryTokens per the design
-      // note above (a narrow decomposition slot must not self-satisfy the
-      // subject for an unrelated original query).
-      const subj = originalPrimaryTokens[0] ?? originalBigrams[0] ?? fullQueryPhrase;
-      subjectPresent = subj ? tokenInBlob(combined, subj) : false;
     } else {
-      const subjectToken = [...originalPrimaryTokens].sort((a, b) => b.length - a.length)[0];
-      subjectPresent = tokenInBlob(combined, subjectToken);
+      // Fix B (2026-07-21, Cluster B / 笔袋) + Cluster-A format-word fix
+      // (2026-07-22, wine label / 字母海报 / 巧克力礼盒 / 人体图解): derive the
+      // subject unit(s) from the ORIGINAL query with FORMAT/output words removed
+      // (see lib/searchSubject.ts). This replaces the old "longest ORIGINAL
+      // primary token = subject" heuristic, which for "head-noun + format"
+      // queries picked the FORMAT word (label > wine, 海报, 礼盒, 图解) and let
+      // wrong-sense content that merely carried the format word read as
+      // subject-present. subjectUnits() keeps Fix B's strictness for
+      // single-concept CJK compounds (require the whole token, not a partial
+      // bigram) and, per the design note above, uses the user's actual query
+      // tokens — NOT this path's possibly-narrower callTokens — so a decomposition
+      // slot cannot self-satisfy the subject for an unrelated original query.
+      const subj = subjectUnits(originalPrimaryTokens, originalBigrams, fullQueryPhrase);
+      subjectPresent = subj.some((u) => tokenInBlob(combined, u));
     }
     const coverageRatio = computeCoverageRatio(combined, originalPrimaryTokens, originalBigrams);
     return {

--- a/app/[locale]/(public)/search/page.tsx
+++ b/app/[locale]/(public)/search/page.tsx
@@ -1085,6 +1085,7 @@ export default async function SearchPage({ params, searchParams }: Props) {
         templateId: x.rec.template_id,
         isMultiTermQuery,
         hasProtectedPhraseQuery,
+        isOriginal: originalIds.has(x.rec.id),
       },
       x.score,
     ),

--- a/app/[locale]/(public)/search/page.tsx
+++ b/app/[locale]/(public)/search/page.tsx
@@ -34,6 +34,15 @@ import {
 import { normalizeSearchQuery } from "@/lib/query_normalize";
 import { getBusinessOverride, applyBusinessOverride, shouldSkipTopicRedirect } from "@/lib/search_business_override";
 import { CONCEPT_SYNONYMS } from "@/lib/template_concept_expansion";
+import { findProtectedPhrases, getAnchorTokens } from "@/lib/searchPhraseProtection";
+import {
+  scoreRecord,
+  applyFamilySaturation,
+  selectFinalCandidates,
+  type FieldHitInfo,
+  type ScoredCandidate,
+} from "@/lib/relevanceScorer";
+import { TOTAL_CANDIDATE_POOL_CAP, PATH_CANDIDATE_CAP } from "@/lib/relevanceScorerConfig";
 import SearchResultsClient from "./SearchResultsClient";
 
 // Threshold below which we trigger the LLM multi-query expansion path
@@ -286,6 +295,23 @@ export default async function SearchPage({ params, searchParams }: Props) {
   }
 
   const tokens = buildSearchTokens(query);
+  // Stage 7/9 scorer: protected phrases / subject are evaluated against
+  // the USER'S ORIGINAL QUERY, computed once here — not re-derived per
+  // retrieval path. A narrow decomposition slot (e.g. output="banner")
+  // has its own tiny token set that would trivially "satisfy" subject
+  // presence for itself while being irrelevant to what the user actually
+  // typed; if every path recomputed its own protected-phrase/subject
+  // context, a record found only via that narrow slot could still get
+  // credited with subjectPresent=true after merging, masking exactly the
+  // kind of collision this scorer exists to catch (confirmed live during
+  // implementation testing: a decomposition "banner" slot alone let a
+  // Marvel Black Widow card keep subjectPresent=true for the query
+  // "black friday banner" even though "black friday" never appeared in
+  // its blob). Always scoring against the ORIGINAL query's subject/phrase
+  // context, regardless of which path found the record, closes this gap.
+  const originalQueryPhraseText = tokens.primary.join(" ");
+  const originalProtectedPhrases = findProtectedPhrases(originalQueryPhraseText);
+  const originalPrimaryTokensForSubject = tokens.primary;
 
   // Pull localized topic displayNames for this locale so e.g. zh "动漫" still
   // resolves to slug "anime". Mirrors the relative-path import style used in
@@ -447,7 +473,79 @@ export default async function SearchPage({ params, searchParams }: Props) {
   // Score every inspiration once; bucket into strict and relaxed pools.
   // Surface strict alone if it's non-empty (precision); otherwise fall
   // back to the relaxed pool. Mirrors the template-i18n two-pass.
-  type ScoredInspiration = { rec: InspRecord; score: number; strict: boolean };
+  type ScoredInspiration = {
+    rec: InspRecord;
+    score: number;
+    strict: boolean;
+    fields: FieldHitInfo;
+  };
+
+  // Direction 6 (phrase protection, scoring half) + Stage 7/9 unified
+  // scorer input. Given the ALREADY-COMPUTED title/tags blobs for a
+  // candidate plus the query's protected phrases, derive the FieldHitInfo
+  // the scorer needs. Kept as a small pure helper so both the template-
+  // promoted fast path and the per-inspiration path can share it.
+  function deriveFieldHits(
+    titleBlob: string,
+    tagsBlob: string,
+    paramsOnlyMatch: boolean,
+    s: ReturnType<typeof scoreBlob>,
+    callTokens: ReturnType<typeof buildSearchTokens>,
+    protectedPhrases: string[],
+    fullQueryPhrase: string,
+    originalPrimaryTokens: string[],
+  ): FieldHitInfo {
+    const combined = titleBlob + " " + tagsBlob;
+    const titleScore = scoreBlob(titleBlob, callTokens);
+    const tagsScore = scoreBlob(tagsBlob, callTokens);
+    const titleHit = titleScore.allPrimary || titleScore.bigramHits > 0;
+    const tagsHit = tagsScore.allPrimary || tagsScore.bigramHits > 0;
+    // Substring-only: the sole match evidence is the CJK bigram fallback
+    // with zero real primary-token hits — the highest-risk collision
+    // shape for unsegmented Chinese queries (see 02_PRODUCTION_SEARCH_CODE_AUDIT.md).
+    const substringOnly = s.primaryHits === 0 && s.bigramHits > 0;
+    // Exact phrase: a protected phrase, or (for multi-token queries) the
+    // full query text itself, appears verbatim in the high-signal blob —
+    // not just "every token present somewhere."
+    let exactPhraseHit = protectedPhrases.some((p) => combined.includes(p));
+    if (!exactPhraseHit && fullQueryPhrase.includes(" ")) {
+      exactPhraseHit = combined.includes(fullQueryPhrase);
+    }
+    // Subject presence: for a protected-phrase query, the subject IS the
+    // phrase. Otherwise, approximate the "core noun" as the longest
+    // ORIGINAL-QUERY primary token (a deliberately simple, explainable
+    // heuristic — see 08_RELEVANCE_SCORER_DESIGN.md for why a full
+    // dependency-parse-grade subject detector is out of scope for a
+    // lightweight text scorer). Deliberately uses originalPrimaryTokens
+    // (the user's actual query), NOT callTokens (this specific path's
+    // possibly much narrower text) — same reasoning as the protected-
+    // phrase case above: a narrow decomposition slot must not be able to
+    // self-satisfy subject presence for an unrelated original query.
+    // Confirmed live during implementation testing: without this,
+    // "plush pillow" surfaced unrelated Chinese solar-term / paper-
+    // cutting content in the top 5 because a generic decomposition slot
+    // happened to share a tag with those records.
+    let subjectPresent: boolean;
+    if (protectedPhrases.length > 0) {
+      const anchors = getAnchorTokens(protectedPhrases);
+      subjectPresent =
+        protectedPhrases.some((p) => combined.includes(p)) ||
+        anchors.some((a) => tokenInBlob(combined, a));
+    } else if (originalPrimaryTokens.length <= 1) {
+      subjectPresent = titleHit || tagsHit;
+    } else {
+      const subjectToken = [...originalPrimaryTokens].sort((a, b) => b.length - a.length)[0];
+      subjectPresent = tokenInBlob(combined, subjectToken);
+    }
+    return {
+      titleHit,
+      tagsHit,
+      paramsOnlyHit: paramsOnlyMatch,
+      exactPhraseHit,
+      substringOnly,
+      subjectPresent,
+    };
+  }
 
   // Inner scorer extracted so the LLM-rewrite path below can call it
   // again per rewrite without duplicating the strict/relaxed two-pass.
@@ -500,9 +598,38 @@ export default async function SearchPage({ params, searchParams }: Props) {
     const scored: ScoredInspiration[] = [];
     // Pre-compute query-token set for the compound-noun guard below.
     const queryTokenSet = new Set(tokens.primary);
+    // Stage 7/9 scorer inputs: deliberately use the OUTER-SCOPE
+    // originalProtectedPhrases / originalQueryPhraseText (the user's
+    // actual typed query) here, NOT a recomputation from this call's
+    // own `tokens` — see the comment at their definition above for why
+    // (a narrow decomposition slot like output="banner" must not be
+    // able to satisfy "black friday"'s protected-phrase/subject check
+    // just because it has no phrase concept of its own).
     for (const r of nanoInspiration as InspRecord[]) {
       if (promoteAllUnderStrictTpl && strictTpl.has(r.template_id)) {
-        scored.push({ rec: r, score: 100, strict: true });
+        // Template-level strict promotion: broad-recall path (see doc
+        // comment above). The signal backing this record IS the
+        // template's own blob (title/category/description), so treat
+        // title+tags as present for scoring purposes; check the actual
+        // template blob for exact-phrase evidence rather than assuming.
+        const tplBlob = templateSearchBlob.get(r.template_id) ?? "";
+        let exactPhraseHit = originalProtectedPhrases.some((p) => tplBlob.includes(p));
+        if (!exactPhraseHit && originalQueryPhraseText.includes(" ")) {
+          exactPhraseHit = tplBlob.includes(originalQueryPhraseText);
+        }
+        scored.push({
+          rec: r,
+          score: 100,
+          strict: true,
+          fields: {
+            titleHit: true,
+            tagsHit: true,
+            paramsOnlyHit: false,
+            exactPhraseHit,
+            substringOnly: false,
+            subjectPresent: true,
+          },
+        });
         continue;
       }
       const localeFields = Object.values(r.locales ?? {}).flatMap((l) => [
@@ -528,6 +655,25 @@ export default async function SearchPage({ params, searchParams }: Props) {
           .join(" ")
       );
       const s = scoreBlob(blob, tokens);
+      // titleBlob / tagsBlob: the same field split the scorer uses to
+      // tell "matched in a high-signal field" from "matched only via a
+      // low-signal params dump" — hoisted out of the demoteToRelaxed
+      // guard below (previously computed conditionally) so every scored
+      // record, not just borderline ones, gets real field-hit info fed
+      // to the Stage 7/9 unified scorer instead of a placeholder.
+      const titleBlob = normalizeForSearch(
+        localeFields.filter((v): v is string => typeof v === "string" && v.length > 0).join(" ")
+      );
+      const topicalBlob = normalizeForSearch(
+        [
+          r.template_id,
+          ...(r.tags ?? []),
+          ...mergedTopics,
+          ...(r.search_aliases ?? []),
+        ]
+          .filter((v): v is string => typeof v === "string" && v.length > 0)
+          .join(" ")
+      );
       // Compound-noun precision guard: a single-token ASCII query that hits
       // an inspiration ONLY because the token is one word inside a multi-word
       // param value (e.g. `snake` matching `plant_name: "snake plant"`) gets
@@ -536,17 +682,8 @@ export default async function SearchPage({ params, searchParams }: Props) {
       // the main precision bug for short single-word queries against
       // param-rich templates (houseplants, fashion, food).
       let demoteToRelaxed = false;
+      let paramsOnlyMatch = false;
       if ((s.allPrimary || s.bigramHits >= bigramThr) && !strictTpl.has(r.template_id)) {
-        const topicalBlob = normalizeForSearch(
-          [
-            r.template_id,
-            ...(r.tags ?? []),
-            ...mergedTopics,
-            ...(r.search_aliases ?? []),
-          ]
-            .filter((v): v is string => typeof v === "string" && v.length > 0)
-            .join(" ")
-        );
         const topicalScore = scoreBlob(topicalBlob, tokens);
         const topicalStrict =
           topicalScore.allPrimary || topicalScore.bigramHits >= bigramThr;
@@ -566,12 +703,23 @@ export default async function SearchPage({ params, searchParams }: Props) {
             }
           }
           if (!paramWholePhrase) demoteToRelaxed = true;
+          else paramsOnlyMatch = true;
         }
       }
+      const fields = deriveFieldHits(
+        titleBlob,
+        topicalBlob,
+        paramsOnlyMatch,
+        s,
+        tokens,
+        originalProtectedPhrases,
+        originalQueryPhraseText,
+        originalPrimaryTokensForSubject,
+      );
       if ((s.allPrimary || s.bigramHits >= bigramThr) && !demoteToRelaxed) {
-        scored.push({ rec: r, score: s.primaryHits + s.bigramHits, strict: true });
+        scored.push({ rec: r, score: s.primaryHits + s.bigramHits, strict: true, fields });
       } else if (s.primaryHits >= relaxedThr && relaxedThr > 0) {
-        scored.push({ rec: r, score: s.primaryHits, strict: false });
+        scored.push({ rec: r, score: s.primaryHits, strict: false, fields });
       }
     }
     return { scored, strictTpl, tplByI18n };
@@ -582,10 +730,34 @@ export default async function SearchPage({ params, searchParams }: Props) {
   // of i18n-template matches (any pass) — drives matchedTemplates below.
   let strictTemplateMatchesUnion = new Set(baseResult.strictTpl);
   let matchedTemplateIdsByI18nUnion = new Set(baseResult.tplByI18n);
+  // Direction 5: templates matched by the ORIGINAL query pass are always
+  // kept (same "original results are a floor" invariant as Direction 1,
+  // applied to the template rail). Templates matched ONLY via rewrite/
+  // decomposition expansion are tracked separately so their contribution
+  // to the rail can be capped below instead of flooding it unconditionally
+  // — confirmed live on V0 that this rail is otherwise uncapped (e.g.
+  // "coffee cup" matched 284/335 templates, see 07_V0_TARGET_CASE_RECONFIRMATION.csv).
+  const templateIdsFromOriginal = new Set(baseResult.tplByI18n);
+  const templateIdsFromExtraPaths = new Map<string, number>(); // tid -> path count
   // Initial inspirations + post-rewrite merge target. The merge uses a
   // by-id map so the highest score per record wins across passes.
   const inspirationById = new Map<string, ScoredInspiration>();
   for (const s of baseResult.scored) inspirationById.set(s.rec.id, s);
+  // Direction 2: record which retrieval path(s) contributed each result
+  // (original / rewrite:<text> / decomposition:<slot>) for explainability.
+  const sourcePathsById = new Map<string, Set<string>>();
+  for (const s of baseResult.scored) sourcePathsById.set(s.rec.id, new Set(["original"]));
+
+  function mergeFields(a: FieldHitInfo, b: FieldHitInfo): FieldHitInfo {
+    return {
+      titleHit: a.titleHit || b.titleHit,
+      tagsHit: a.tagsHit || b.tagsHit,
+      paramsOnlyHit: a.paramsOnlyHit || b.paramsOnlyHit,
+      exactPhraseHit: a.exactPhraseHit || b.exactPhraseHit,
+      substringOnly: a.substringOnly && b.substringOnly,
+      subjectPresent: a.subjectPresent || b.subjectPresent,
+    };
+  }
 
   // P0.2 multi-query retrieval — when the original query returns thin
   // results (< LOW_RESULT_THRESHOLD), expand to up to 8 retrieval paths:
@@ -626,7 +798,11 @@ export default async function SearchPage({ params, searchParams }: Props) {
     const multi = await getMultiQueryPaths(query);
     const extraPaths = flattenPaths(query, multi);
     if (extraPaths.length > 0) {
+      const rewriteSet = new Set(multi.rewrites.map((r) => r.trim().toLowerCase()));
       for (const path of extraPaths) {
+        const pathLabel = rewriteSet.has(path.trim().toLowerCase())
+          ? `rewrite:${path}`
+          : `decomposition:${path}`;
         const pathTokens = buildSearchTokens(path);
         // Inspiration-level matching only for expanded paths — see the
         // promoteAllUnderStrictTpl=false branch in scoreQueryTokens.
@@ -634,35 +810,51 @@ export default async function SearchPage({ params, searchParams }: Props) {
         // inspiration under any watercolor template.
         const pathResult = scoreQueryTokens(pathTokens, false);
         for (const id of pathResult.strictTpl) strictTemplateMatchesUnion.add(id);
-        for (const id of pathResult.tplByI18n) matchedTemplateIdsByI18nUnion.add(id);
+        // Direction 5: templates contributed ONLY by this rewrite/decomp
+        // path (not already backed by the original query) are tracked
+        // with a per-template path count, capped below rather than
+        // added to the rail unconditionally.
+        for (const id of pathResult.tplByI18n) {
+          matchedTemplateIdsByI18nUnion.add(id);
+          if (!templateIdsFromOriginal.has(id)) {
+            templateIdsFromExtraPaths.set(id, (templateIdsFromExtraPaths.get(id) ?? 0) + 1);
+          }
+        }
+        // Direction 5: cap how many NEW (not already in the pool)
+        // candidates a single path may contribute. A path that already
+        // hits records already in the pool (agreement, good) is never
+        // capped; only its contribution of brand-new records is capped —
+        // this is what stops one over-broad path from dumping hundreds
+        // of unrelated new candidates while still letting genuine
+        // cross-path agreement boost existing candidates freely.
+        let newFromThisPath = 0;
         for (const s of pathResult.scored) {
           const prev = inspirationById.get(s.rec.id);
-          // Keep the max score per record across passes; promote strict
-          // if any pass saw it as strict so the strict-filter below
-          // doesn't drop a path hit just because the original was relaxed.
+          if (!prev && newFromThisPath >= PATH_CANDIDATE_CAP) continue;
+          if (!prev) newFromThisPath++;
           if (!prev || s.score > prev.score || (s.strict && !prev.strict)) {
-            inspirationById.set(s.rec.id, s);
+            const mergedFields = prev ? mergeFields(prev.fields, s.fields) : s.fields;
+            inspirationById.set(s.rec.id, { ...s, fields: mergedFields });
+          } else {
+            // Lower-scoring pass still contributes field evidence.
+            inspirationById.set(s.rec.id, { ...prev, fields: mergeFields(prev.fields, s.fields) });
           }
           pathHitsById.set(s.rec.id, (pathHitsById.get(s.rec.id) ?? 0) + 1);
+          const existing = sourcePathsById.get(s.rec.id) ?? new Set<string>();
+          existing.add(pathLabel);
+          sourcePathsById.set(s.rec.id, existing);
         }
       }
       usedRewrites = multi.rewrites;
       usedPathsCount = 1 + extraPaths.length;
     }
   }
-
-  // Apply multi-hit re-rank boost. +8% per extra path the record is
-  // covered by, capped at +40% (5 hits or more) to avoid letting a
-  // popular-tag record swamp a literal-noun match. Only applied when
-  // multi-query expansion actually ran (usedPathsCount > 1).
-  if (usedPathsCount > 1) {
-    for (const [id, scored] of inspirationById) {
-      const hits = pathHitsById.get(id) ?? 1;
-      if (hits <= 1) continue;
-      const boost = 1 + Math.min(hits - 1, 5) * 0.08;
-      inspirationById.set(id, { ...scored, score: scored.score * boost });
-    }
-  }
+  // NOTE: the old multiplicative "+8% per extra path, capped +40%" boost
+  // has been removed — cross-path agreement is now a scorer input
+  // (relevanceScorer.ts path_agreement, driven by pathHitsById below)
+  // instead of a raw score multiplier, consistent with Direction 5's
+  // requirement that "某条宽泛路径不能靠候选数量主导" (a broad path can't
+  // dominate purely by candidate count / hit count).
 
   // Concept-expansion secondary pass — surfaces templates whose blobs contain
   // semantically-related terms rather than the exact query tokens. Only targets
@@ -700,13 +892,49 @@ export default async function SearchPage({ params, searchParams }: Props) {
     }
   }
 
-  const allScored = Array.from(inspirationById.values());
-  const hasStrict = allScored.some((x) => x.strict);
-  let inspirations = allScored
-    .filter((x) => (hasStrict ? x.strict : true))
-    .sort((a, b) => b.score - a.score)
-    .slice(0, 80)
-    .map((x) => x.rec);
+  // Direction 5 (template rail flooding fix): templates matched by the
+  // ORIGINAL query pass are always kept in full (floor invariant). Extra
+  // templates contributed ONLY by rewrite/decomposition paths are capped
+  // at TOTAL_CANDIDATE_POOL_CAP total (same cap used for inspirations),
+  // prioritized by how many distinct paths independently matched them —
+  // directly targets the confirmed live-V0 flooding case (coffee cup:
+  // 284/335 templates matched via 5 rewrite/decomp paths, see
+  // 07_V0_TARGET_CASE_RECONFIRMATION.csv SUB_01).
+  if (templateIdsFromExtraPaths.size > 0) {
+    const budget = Math.max(0, TOTAL_CANDIDATE_POOL_CAP - templateIdsFromOriginal.size);
+    const rankedExtras = [...templateIdsFromExtraPaths.entries()].sort((a, b) => b[1] - a[1]);
+    const keptExtras = new Set(rankedExtras.slice(0, budget).map(([tid]) => tid));
+    for (const [tid] of rankedExtras) {
+      if (!keptExtras.has(tid)) matchedTemplateIdsByI18nUnion.delete(tid);
+    }
+  }
+
+  // Stage 7/9 unified relevance scorer replaces the old binary hasStrict
+  // gate ("any strict hit anywhere ⇒ drop every relaxed record, even the
+  // original query's own relaxed-only results"). Every candidate — from
+  // any path, strict or relaxed — is scored on the same explainable
+  // scale; Direction 1's floor invariant (original_results preserved
+  // when non-empty) is enforced by selectFinalCandidates, and Direction
+  // 5's Template Family Saturation is enforced by applyFamilySaturation.
+  // See lib/relevanceScorer.ts and 08_RELEVANCE_SCORER_DESIGN.md.
+  const originalIds = new Set(baseResult.scored.map((s) => s.rec.id));
+  const scoredCandidates: ScoredCandidate[] = Array.from(inspirationById.values()).map((x) => ({
+    id: x.rec.id,
+    templateId: x.rec.template_id,
+    isOriginal: originalIds.has(x.rec.id),
+    breakdown: scoreRecord(
+      x.fields,
+      { pathHits: pathHitsById.get(x.rec.id) ?? 1, templateId: x.rec.template_id },
+      x.score,
+    ),
+  }));
+  const familyAdjusted = applyFamilySaturation(scoredCandidates);
+  const finalSelected = selectFinalCandidates(familyAdjusted, originalIds);
+  const recById = new Map(Array.from(inspirationById.values()).map((x) => [x.rec.id, x.rec]));
+  let inspirations = finalSelected
+    .slice(0, TOTAL_CANDIDATE_POOL_CAP)
+    .map((c) => recById.get(c.id))
+    .filter((r): r is InspRecord => !!r);
 
   // Intent narrow (?within=<output-type-slug>): keep only inspirations
   // whose parent template OR own topics+tags carry the slug. Matches the

--- a/app/[locale]/(public)/search/page.tsx
+++ b/app/[locale]/(public)/search/page.tsx
@@ -598,7 +598,22 @@ export default async function SearchPage({ params, searchParams }: Props) {
         protectedPhrases.some((p) => combined.includes(p)) ||
         anchors.some((a) => tokenInBlob(combined, a));
     } else if (originalPrimaryTokens.length <= 1) {
-      subjectPresent = titleHit || tagsHit;
+      // Fix B (2026-07-21, scorer-v1.1 eval Cluster B / 笔袋 flagship): make
+      // single-token subject-presence CONSISTENT with the multi-term branch
+      // below — require the ORIGINAL query's subject token to actually appear
+      // (whole-token for ASCII, substring for CJK) in the title/tags blob, NOT
+      // the `titleHit || tagsHit` shortcut, which is derived from THIS path's
+      // (possibly rewritten/decomposed) callTokens and includes a CJK
+      // bigram/substring fallback. That shortcut let an off-subject non-original
+      // candidate whose only 袋-content was an alias like 帆布袋设计 (canvas tote
+      // bag) read as subject-present for the query 笔袋 — via a decomposition
+      // slot's CJK bigram — and so bypass NON_ORIGINAL_OFFSUBJECT_EXTRA_PENALTY
+      // and the result-rich gate, ranking #1 over genuine stationery (Step-6
+      // residual, confirmed live). Uses originalPrimaryTokens per the design
+      // note above (a narrow decomposition slot must not self-satisfy the
+      // subject for an unrelated original query).
+      const subj = originalPrimaryTokens[0] ?? originalBigrams[0] ?? fullQueryPhrase;
+      subjectPresent = subj ? tokenInBlob(combined, subj) : false;
     } else {
       const subjectToken = [...originalPrimaryTokens].sort((a, b) => b.length - a.length)[0];
       subjectPresent = tokenInBlob(combined, subjectToken);

--- a/app/[locale]/(public)/search/page.tsx
+++ b/app/[locale]/(public)/search/page.tsx
@@ -243,6 +243,33 @@ function scoreBlob(
   };
 }
 
+// V2-R3 mechanism B: fraction of the ORIGINAL query's required terms
+// found in a candidate blob. Required terms are the original query's
+// primary tokens for multi-token (typically EN) queries, or the
+// original query's bigrams for an unsegmented CJK compound (see
+// isMultiTermQuery doc above for why bigrams are the CJK equivalent).
+// Always uses the ORIGINAL query's terms/bigrams (never a specific
+// rewrite/decomposition path's), matching the existing subjectPresent
+// discipline -- a narrow path must not be able to self-satisfy coverage
+// for the user's actual query. Returns 1 (trivial full coverage) for a
+// genuine single-term query, matching relevanceScorer.ts's expectation
+// that single-term queries are unaffected by the coverage gate.
+function computeCoverageRatio(
+  combinedBlob: string,
+  originalPrimaryTokens: string[],
+  originalBigrams: string[],
+): number {
+  if (originalPrimaryTokens.length > 1) {
+    const matched = originalPrimaryTokens.filter((t) => tokenInBlob(combinedBlob, t)).length;
+    return matched / originalPrimaryTokens.length;
+  }
+  if (originalBigrams.length > 1) {
+    const matched = originalBigrams.filter((b) => combinedBlob.includes(b)).length;
+    return matched / originalBigrams.length;
+  }
+  return 1;
+}
+
 export default async function SearchPage({ params, searchParams }: Props) {
   // Intent narrowing: chip aggregator (commit 17b56686) sends users to
   // /search?q=<query>&within=<output-type-slug>. Reuses the full /search
@@ -312,6 +339,18 @@ export default async function SearchPage({ params, searchParams }: Props) {
   const originalQueryPhraseText = tokens.primary.join(" ");
   const originalProtectedPhrases = findProtectedPhrases(originalQueryPhraseText);
   const originalPrimaryTokensForSubject = tokens.primary;
+  // V2-R3 mechanism B inputs (relevanceScorer.ts required-coverage /
+  // isolated-hit cap) -- query-level, computed once. A query is
+  // "multi-term" when it decomposes into 2+ required terms: 2+
+  // whitespace/punctuation-separated primary tokens (EN and similar), or
+  // 2+ bigrams for an unsegmented CJK compound (the tokenizer never
+  // splits CJK on whitespace, so a query like "新品横幅" is one primary
+  // token but 3 bigrams -- bigram coverage is the CJK-consistent
+  // equivalent of primary-token coverage for EN). See
+  // 05_V2_R3_MINIMAL_FIX_DESIGN.md section 5 / relevanceScorerConfig.ts.
+  const isMultiTermQuery =
+    originalPrimaryTokensForSubject.length > 1 || tokens.bigrams.length > 1;
+  const hasProtectedPhraseQuery = originalProtectedPhrases.length > 0;
 
   // Pull localized topic displayNames for this locale so e.g. zh "动漫" still
   // resolves to slug "anime". Mirrors the relative-path import style used in
@@ -520,6 +559,7 @@ export default async function SearchPage({ params, searchParams }: Props) {
     protectedPhrases: string[],
     fullQueryPhrase: string,
     originalPrimaryTokens: string[],
+    originalBigrams: string[],
   ): FieldHitInfo {
     const combined = titleBlob + " " + tagsBlob;
     const titleScore = scoreBlob(titleBlob, callTokens);
@@ -563,6 +603,7 @@ export default async function SearchPage({ params, searchParams }: Props) {
       const subjectToken = [...originalPrimaryTokens].sort((a, b) => b.length - a.length)[0];
       subjectPresent = tokenInBlob(combined, subjectToken);
     }
+    const coverageRatio = computeCoverageRatio(combined, originalPrimaryTokens, originalBigrams);
     return {
       titleHit,
       tagsHit,
@@ -570,6 +611,7 @@ export default async function SearchPage({ params, searchParams }: Props) {
       exactPhraseHit,
       substringOnly,
       subjectPresent,
+      coverageRatio,
     };
   }
 
@@ -632,65 +674,11 @@ export default async function SearchPage({ params, searchParams }: Props) {
     // able to satisfy "black friday"'s protected-phrase/subject check
     // just because it has no phrase concept of its own).
     for (const r of nanoInspiration as InspRecord[]) {
-      if (promoteAllUnderStrictTpl && strictTpl.has(r.template_id)) {
-        // Template-level strict promotion: broad-recall path (see doc
-        // comment above) -- retrieval/promotion itself is UNCHANGED (an
-        // inspiration is still promoted whenever its template strict-
-        // matches anywhere in the full blob, preserving recall / not
-        // risking a new zero-result case). What changed (Stage 10 root-
-        // cause fix) is the SCORING evidence: previously this branch
-        // hardcoded titleHit/tagsHit/subjectPresent=true unconditionally,
-        // which meant a match buried in the template's long free-text
-        // `content.sections.what` "how it works" prose scored identically
-        // to a match in the title/category. Confirmed live: template-
-        // mbti-breakingbad's sections.what literally contains "periodic
-        // table typography" (a decorative motif description, not
-        // periodic-table content), which strict-matched "periodic table"
-        // / "元素周期表" and promoted all 20 Breaking-Bad character cards
-        // with no scoring penalty at all — see
-        // 15_BROAD_TEMPLATE_ROOT_CAUSE_ANALYSIS.md. Now titleHit /
-        // subjectPresent are evaluated against templateTitleCategoryBlob
-        // (title+category ONLY, no description/how-to text); a match
-        // that only exists in the broader description still promotes the
-        // record (recall preserved) but is correctly scored as weaker
-        // evidence.
-        const tplTitleCatBlob = templateTitleCategoryBlob.get(r.template_id) ?? "";
-        let exactPhraseHit = originalProtectedPhrases.some((p) => tplTitleCatBlob.includes(p));
-        if (!exactPhraseHit && originalQueryPhraseText.includes(" ")) {
-          exactPhraseHit = tplTitleCatBlob.includes(originalQueryPhraseText);
-        }
-        const titleHit =
-          scoreBlob(tplTitleCatBlob, tokens).allPrimary ||
-          scoreBlob(tplTitleCatBlob, tokens).bigramHits > 0;
-        let subjectPresent: boolean;
-        if (originalProtectedPhrases.length > 0) {
-          const anchors = getAnchorTokens(originalProtectedPhrases);
-          subjectPresent =
-            originalProtectedPhrases.some((p) => tplTitleCatBlob.includes(p)) ||
-            anchors.some((a) => tokenInBlob(tplTitleCatBlob, a));
-        } else if (originalPrimaryTokensForSubject.length <= 1) {
-          subjectPresent = titleHit;
-        } else {
-          const subjectToken = [...originalPrimaryTokensForSubject].sort(
-            (a, b) => b.length - a.length
-          )[0];
-          subjectPresent = tokenInBlob(tplTitleCatBlob, subjectToken);
-        }
-        scored.push({
-          rec: r,
-          score: 100,
-          strict: true,
-          fields: {
-            titleHit,
-            tagsHit: true, // the full blob (tags/topics/description) did strict-match by definition
-            paramsOnlyHit: false,
-            exactPhraseHit,
-            substringOnly: false,
-            subjectPresent,
-          },
-        });
-        continue;
-      }
+      // Per-inspiration blobs, computed unconditionally (both the
+      // template-promoted and standard branches below need them --
+      // V2-R3 mechanism A requires the template-promoted branch to be
+      // able to evaluate each sibling's OWN evidence, not just the
+      // template's).
       const localeFields = Object.values(r.locales ?? {}).flatMap((l) => [
         l?.title,
         l?.category,
@@ -713,7 +701,6 @@ export default async function SearchPage({ params, searchParams }: Props) {
           .filter((v): v is string => typeof v === "string" && v.length > 0)
           .join(" ")
       );
-      const s = scoreBlob(blob, tokens);
       // titleBlob / tagsBlob: the same field split the scorer uses to
       // tell "matched in a high-signal field" from "matched only via a
       // low-signal params dump" — hoisted out of the demoteToRelaxed
@@ -733,6 +720,111 @@ export default async function SearchPage({ params, searchParams }: Props) {
           .filter((v): v is string => typeof v === "string" && v.length > 0)
           .join(" ")
       );
+      const s = scoreBlob(blob, tokens);
+      if (promoteAllUnderStrictTpl && strictTpl.has(r.template_id)) {
+        // Template-level strict promotion: broad-recall path (see doc
+        // comment above) -- retrieval/promotion itself is UNCHANGED (an
+        // inspiration is still promoted whenever its template strict-
+        // matches anywhere in the full blob, preserving recall / not
+        // risking a new zero-result case). What changed (Stage 10 root-
+        // cause fix) is the SCORING evidence: previously this branch
+        // hardcoded titleHit/tagsHit/subjectPresent=true unconditionally,
+        // which meant a match buried in the template's long free-text
+        // `content.sections.what` "how it works" prose scored identically
+        // to a match in the title/category. Confirmed live: template-
+        // mbti-breakingbad's sections.what literally contains "periodic
+        // table typography" (a decorative motif description, not
+        // periodic-table content), which strict-matched "periodic table"
+        // / "元素周期表" and promoted all 20 Breaking-Bad character cards
+        // with no scoring penalty at all — see
+        // 15_BROAD_TEMPLATE_ROOT_CAUSE_ANALYSIS.md.
+        //
+        // V2-R3 mechanism A (per-inspiration re-scoring): the residual
+        // defect Direction 7 above did NOT fix is that titleHit/
+        // subjectPresent were still computed at the TEMPLATE level (the
+        // SAME value copied onto every sibling under the template) and
+        // tagsHit was unconditionally hardcoded true for every sibling
+        // regardless of that sibling's own content. Fix: evaluate each
+        // sibling against its OWN title/tags blob (the exact same
+        // titleBlob/topicalBlob the non-template branch below already
+        // uses) via the shared deriveFieldHits helper. Two-tier fallback:
+        //   - Tier 1 (used whenever the sibling has ANY own descriptive
+        //     content -- own locale title/category, own tags, own
+        //     topics, or own search_aliases): score against that own
+        //     content ONLY. A genuinely on-topic sibling still scores
+        //     exactly as it does today (its own blob matches); an
+        //     unrelated sibling under the same promoted template no
+        //     longer inherits the template's flat score.
+        //   - Tier 2 (safe fallback, ONLY when the sibling has ZERO own
+        //     descriptive content at all): fall back to today's
+        //     template-level evidence so a genuinely content-less record
+        //     is not unfairly zeroed out just for lacking metadata.
+        // Retrieval/inclusion is untouched either way -- every sibling
+        // is still pushed to `scored` with score:100 (base_retrieval
+        // stays capped at 20 regardless of tier), preserving Direction 1
+        // existence-floor recall. Only the FIELD evidence that feeds
+        // scoreRecord's title/tags/subject/coverage terms changes.
+        const tplTitleCatBlob = templateTitleCategoryBlob.get(r.template_id) ?? "";
+        let tplExactPhraseHit = originalProtectedPhrases.some((p) => tplTitleCatBlob.includes(p));
+        if (!tplExactPhraseHit && originalQueryPhraseText.includes(" ")) {
+          tplExactPhraseHit = tplTitleCatBlob.includes(originalQueryPhraseText);
+        }
+        const tplTitleHit =
+          scoreBlob(tplTitleCatBlob, tokens).allPrimary ||
+          scoreBlob(tplTitleCatBlob, tokens).bigramHits > 0;
+        let tplSubjectPresent: boolean;
+        if (originalProtectedPhrases.length > 0) {
+          const anchors = getAnchorTokens(originalProtectedPhrases);
+          tplSubjectPresent =
+            originalProtectedPhrases.some((p) => tplTitleCatBlob.includes(p)) ||
+            anchors.some((a) => tokenInBlob(tplTitleCatBlob, a));
+        } else if (originalPrimaryTokensForSubject.length <= 1) {
+          tplSubjectPresent = tplTitleHit;
+        } else {
+          const subjectToken = [...originalPrimaryTokensForSubject].sort(
+            (a, b) => b.length - a.length
+          )[0];
+          tplSubjectPresent = tokenInBlob(tplTitleCatBlob, subjectToken);
+        }
+        const templateFallbackFields: FieldHitInfo = {
+          titleHit: tplTitleHit,
+          tagsHit: true, // the full blob (tags/topics/description) did strict-match by definition
+          paramsOnlyHit: false,
+          exactPhraseHit: tplExactPhraseHit,
+          substringOnly: false,
+          subjectPresent: tplSubjectPresent,
+          coverageRatio: computeCoverageRatio(
+            tplTitleCatBlob,
+            originalPrimaryTokensForSubject,
+            tokens.bigrams
+          ),
+        };
+        const hasOwnContent =
+          localeFields.some((v): v is string => typeof v === "string" && v.length > 0) ||
+          (r.tags?.length ?? 0) > 0 ||
+          (r.topics?.length ?? 0) > 0 ||
+          (r.search_aliases?.length ?? 0) > 0;
+        const fieldsForSibling = hasOwnContent
+          ? deriveFieldHits(
+              titleBlob,
+              topicalBlob,
+              false,
+              s,
+              tokens,
+              originalProtectedPhrases,
+              originalQueryPhraseText,
+              originalPrimaryTokensForSubject,
+              tokens.bigrams,
+            )
+          : templateFallbackFields;
+        scored.push({
+          rec: r,
+          score: 100,
+          strict: true,
+          fields: fieldsForSibling,
+        });
+        continue;
+      }
       // Compound-noun precision guard: a single-token ASCII query that hits
       // an inspiration ONLY because the token is one word inside a multi-word
       // param value (e.g. `snake` matching `plant_name: "snake plant"`) gets
@@ -774,6 +866,7 @@ export default async function SearchPage({ params, searchParams }: Props) {
         originalProtectedPhrases,
         originalQueryPhraseText,
         originalPrimaryTokensForSubject,
+        tokens.bigrams,
       );
       if ((s.allPrimary || s.bigramHits >= bigramThr) && !demoteToRelaxed) {
         scored.push({ rec: r, score: s.primaryHits + s.bigramHits, strict: true, fields });
@@ -815,6 +908,10 @@ export default async function SearchPage({ params, searchParams }: Props) {
       exactPhraseHit: a.exactPhraseHit || b.exactPhraseHit,
       substringOnly: a.substringOnly && b.substringOnly,
       subjectPresent: a.subjectPresent || b.subjectPresent,
+      // V2-R3 mechanism B: keep the BETTER (higher) coverage seen across
+      // paths -- a record two independent paths converge on is at least
+      // as well-covered as either path alone found it.
+      coverageRatio: Math.max(a.coverageRatio, b.coverageRatio),
     };
   }
 
@@ -983,7 +1080,12 @@ export default async function SearchPage({ params, searchParams }: Props) {
     isOriginal: originalIds.has(x.rec.id),
     breakdown: scoreRecord(
       x.fields,
-      { pathHits: pathHitsById.get(x.rec.id) ?? 1, templateId: x.rec.template_id },
+      {
+        pathHits: pathHitsById.get(x.rec.id) ?? 1,
+        templateId: x.rec.template_id,
+        isMultiTermQuery,
+        hasProtectedPhraseQuery,
+      },
       x.score,
     ),
   }));

--- a/docs/search-and-content.md
+++ b/docs/search-and-content.md
@@ -52,6 +52,8 @@ A bug in any one thread can leak across — most often we discover the wrong thr
 
 **Runbook:** [`docs/search-quality.md`](./search-quality.md). Already detailed there; recapping the open items:
 
+**Relevance scorer — V2-R3 → R1 (2026-07-21, in revision):** the unified deterministic `scoreRecord` (branch `baobao/search-relevance-prod-main-v2-r3-root-cause-fix-2026-07-19`) replaced V0's binary `hasStrict` gate. The search-eval-07-21 review (six queries improved: 电影海报/sticker pack/product photo/日历/logo/人体图解) flagged two structural issues from the **uniform** weight schema: (1) off-subject candidates from rewrite/decomposition paths leak in and rank high on thin queries (**笔袋** regression — western-food + Gemini posters injected above the relevant stationery card); (2) no result-count awareness (**促销海报** keeps an irrelevant 4th). **R1** (scorer `v1.1`) extends the strict/relaxed distinction into a per-path weighting + a result-count-aware subject gate — full change log + per-case rationale in [`docs/search-relevance-v2r3-r1-2026-07-21.md`](./search-relevance-v2r3-r1-2026-07-21.md). Live re-eval + full-benchmark run pending before prod promotion.
+
 ### Open follow-ups
 1. **Confirm `SEARCH_LOWRESULT` in admin portal.** The frontend ships the event (commit `8217070`), the Postgres enum has the value (migration ran 2026-05-18, verified via `pg_enum`). But `curify_background/app/crud/admin.py` lines 751-798 only aggregates `SEARCH_NORESULT` — the low-result panel hasn't been added. Until that lands, the low-result events accumulate in the DB but nobody surfaces them. **Half-day backend task.**
 

--- a/docs/search-quality.md
+++ b/docs/search-quality.md
@@ -271,4 +271,17 @@ Re-run the click-attribution SQL. Compare result_ctr_pct against the 5.5% baseli
 
 ---
 
+## V2-R3 unified relevance scorer → R1 (2026-07-19 → 2026-07-21)
+
+`lib/relevanceScorer.ts` + `lib/relevanceScorerConfig.ts` replace V0's binary `hasStrict` gate + `score = primaryHits + bigramHits` with a single explainable weighted score per candidate (`scoreRecord`), applied in `app/[locale]/(public)/search/page.tsx` and gated by `selectFinalCandidates` (Direction-1 floor invariant) + `applyFamilySaturation` (family de-duplication). Branch `baobao/search-relevance-prod-main-v2-r3-root-cause-fix-2026-07-19`.
+
+**R1 (scorer `v1.1.0-2026-07-21`)** — from the search-eval-07-21 review (`raw/search-eval-07-21/`). The uniform weight schema let off-subject rewrite/decomposition candidates rank high on thin queries (**笔袋** regression: food/Gemini posters above the relevant stationery card) and had no result-count awareness (**促销海报** irrelevant 4th). Three additive mechanisms, an *extension* of the strict/relaxed distinction (not a return to the binary gate):
+1. **Per-path base trust** — `base_retrieval` counts at `NON_ORIGINAL_BASE_FACTOR` (0.5) for non-original candidates (a rewrite's token-overlap is weaker evidence than a match on the user's own query).
+2. **Non-original off-subject demotion** — `NON_ORIGINAL_OFFSUBJECT_EXTRA_PENALTY` (−10) added to `missing_subject_penalty` when a candidate is off-subject AND non-original → drops the 笔袋 food/Gemini profile below the floor, without touching on-subject relaxed results.
+3. **Result-count-aware subject gate** — when a query is result-rich (≥ `RESULT_RICH_MIN_ONSUBJECT` = 8 on-subject candidates), non-original candidates must carry the subject to be included (prunes the off-subject tail); thin queries are untouched.
+
+Full per-case analysis + preserved wins + residuals: [`docs/search-relevance-v2r3-r1-2026-07-21.md`](./search-relevance-v2r3-r1-2026-07-21.md). Tests: `lib/__tests__/relevanceScorer.test.ts` (37, run via `vitest.unit.config.ts`). **Not yet prod-promoted** — needs live re-eval + full-benchmark run.
+
+---
+
 _This doc is the source of truth for search quality work. Update after each push that touches the surfaces above._

--- a/docs/search-relevance-v2r3-r1-2026-07-21.md
+++ b/docs/search-relevance-v2r3-r1-2026-07-21.md
@@ -43,8 +43,14 @@ All additive to `scoreRecord` / `selectFinalCandidates`; **an extension of the s
 - Never-zero guarantee when original is empty (top-N fallback ignores both floor and gate).
 - No new LLM calls / embeddings / learned reranker — every signal deterministic from catalog+query text.
 
+### Fix B — landed 2026-07-22 (single-token subject-presence bypass)
+The scorer-v1.1 full-326 eval (`visual-search-adhoc/…/scorer-v1.1-evaluation-2026-07-21`) confirmed this residual live: for 笔袋 the flagship regressed (PARTIAL→FAIL) because an off-subject non-original candidate (a canvas-tote-bag food template whose only 袋-content is the alias `帆布袋设计`, no `笔` char) read as **subject-present** and bypassed mechanism 2's `−10` penalty and mechanism 3's rich-gate. Root cause: the single-token branch of `deriveFieldHits` (`page.tsx`) computed `subjectPresent = titleHit || tagsHit`, where those hits come from *this path's* (rewritten/decomposed) `callTokens` and include a CJK bigram/substring fallback — so a decomposition slot's bigram (`帆布袋`) satisfied it.
+
+**Fix:** make the single-token branch consistent with the multi-term branch — `subjectPresent = tokenInBlob(combined, subj)` where `subj` is the ORIGINAL query's subject token (`originalPrimaryTokens[0] ?? originalBigrams[0] ?? fullQueryPhrase`), a whole-token (ASCII) / substring (CJK) hit against the record's own blob, independent of the path's callTokens. The food (no `笔袋`) → `subjectPresent=false` → mechanisms 2+3 fire → dropped; genuine `Stationery`/`en-zh` cards (which literally contain `笔袋`) stay. Multi-term wins are untouched (different branch); single-token wins (`logo`, `日历`) keep their subject because their relevant results carry the token. Tradeoff to watch in re-eval: a CJK single-token query whose only relevant items are English-tagged (no CJK term) loses subject-presence — bounded, and the never-empty + original-floor invariants prevent new zeros. `tsc` clean; 37/37 scorer units still pass (they assert scoreRecord/selectFinalCandidates given a subjectPresent, unaffected by this upstream fix).
+
+Cluster A (multi-term head-noun/modifier: wine label, 字母海报, banner→"Bruce Banner"; and the 人体图解 preserved-win break) is the **next** lever — not in this commit; land + re-gate B first.
+
 ### Known residual (follow-up, not blocking)
-- `subjectPresent` for single-token CJK queries is the weak `titleHit || tagsHit` heuristic; a candidate with a *spurious* subject-token hit still reads as on-subject and escapes both mechanisms 2 and 3 (it is only demoted by mechanism 1). A stronger single-token subject test (e.g. requiring the hit in title, not just tags) is the next lever if 笔袋-class residue remains.
 - Calibration used the eval-07-21 case set only, per the standing prohibition on query-by-query overfitting against the full 326-query benchmark. Re-run the benchmark before promoting to prod.
 
 ## Verification

--- a/docs/search-relevance-v2r3-r1-2026-07-21.md
+++ b/docs/search-relevance-v2r3-r1-2026-07-21.md
@@ -48,12 +48,36 @@ The scorer-v1.1 full-326 eval (`visual-search-adhoc/…/scorer-v1.1-evaluation-2
 
 **Fix:** make the single-token branch consistent with the multi-term branch — `subjectPresent = tokenInBlob(combined, subj)` where `subj` is the ORIGINAL query's subject token (`originalPrimaryTokens[0] ?? originalBigrams[0] ?? fullQueryPhrase`), a whole-token (ASCII) / substring (CJK) hit against the record's own blob, independent of the path's callTokens. The food (no `笔袋`) → `subjectPresent=false` → mechanisms 2+3 fire → dropped; genuine `Stationery`/`en-zh` cards (which literally contain `笔袋`) stay. Multi-term wins are untouched (different branch); single-token wins (`logo`, `日历`) keep their subject because their relevant results carry the token. Tradeoff to watch in re-eval: a CJK single-token query whose only relevant items are English-tagged (no CJK term) loses subject-presence — bounded, and the never-empty + original-floor invariants prevent new zeros. `tsc` clean; 37/37 scorer units still pass (they assert scoreRecord/selectFinalCandidates given a subjectPresent, unaffected by this upstream fix).
 
-Cluster A (multi-term head-noun/modifier: wine label, 字母海报, banner→"Bruce Banner"; and the 人体图解 preserved-win break) is the **next** lever — not in this commit; land + re-gate B first.
+### Fix A (Cluster A) — landed 2026-07-22 (format-word-aware subject)
+
+Cluster A = multi-term **head-noun + format** queries where the scorer picked the wrong subject. `deriveFieldHits` approximated a query's subject as its **longest ORIGINAL token**; for "head-noun + format/output" queries that is almost always the FORMAT word, not the theme:
+
+| Query | longest token (old subject) | correct subject | wrong-sense winner it promoted |
+|---|---|---|---|
+| wine **label** | `label` (5 > `wine` 4) | wine | "label printer" / blank product-label mockups |
+| 字母**海报** (alphabet poster) | `海报` wins the compound | 字母 (alphabet) | MBTI/generic "poster" group shots |
+| 巧克力**礼盒** (chocolate gift-box) | `礼盒` | 巧克力 (chocolate) | generic gift-box / hamper merch |
+| 人体**图解** (anatomy diagram) | `图解` | 人体 (human body) | architecture / how-to "图解" explainers |
+
+Because the wrong-sense content carries the format word, it read as subject-present (`+MISSING_SUBJECT` avoided) while the genuine head-noun results — which lack the format word — took the `−15` missing-subject penalty and sank. Confirmed live on all four via scorer instrumentation (e.g. wine label: subject picked = `label` → label-printers `subj=1`, actual wines `subj=0 → −4`).
+
+**Fix:** the subject is the query's **theme / head-noun content — the non-format token(s)**. New `lib/searchSubject.ts` exports `subjectUnits(primaryTokens, bigrams, fullQueryPhrase)` and a `FORMAT_TOKENS` lexicon; `deriveFieldHits`'s single-token + multi-term branches collapse into `subjectPresent = subjectUnits(...).some(u => tokenInBlob(combined, u))`.
+
+- **Segmented query** (`wine label`) → content primary tokens (`wine`); a candidate carrying only `label` is off-subject → `−15` → demoted.
+- **CJK compound with a format bigram** (`字母海报` = 字母 + 海报, `人体图解` = 人体 + 图解) → the non-format content bigrams (`字母` / `人体`); wrong-sense results with only `海报` / `图解` are off-subject.
+- **Single concept** — ASCII single word (`logo`) or CJK compound with **no** format word (`笔袋`, `元素周期表`) → the whole token. This **preserves Fix B's strictness** (require the full compound, never a partial bigram), so a record carrying only `元素` is not subject-present for `元素周期表`.
+- **All-format query** (`poster`) → falls back to the tokens themselves so a bare-format query still has a subject.
+
+**Leverages the taxonomy (per review Q).** `FORMAT_TOKENS`' English entries are the format/output subset of `lib/taxonomy.json` `content_shapes` + `information_types` (poster, card, flashcard, grid, packaging, map, quote, timeline, infographic…) — the same **subject-vs-shape** separation the taxonomy already draws, not a parallel hand-rolled axis. The taxonomy carries **no CJK shape surface forms** (海报/图解/礼盒/包装 all absent), yet every confirmed CJK Cluster-A regression hinges on one, so the CJK entries are a curated 2-char supplement. Calibration guardrail baked into tests: theme words that merely co-occur with a format (**sticker**, **logo**, map地图, recipe, menu) are kept OUT — so `sticker pack` still resolves subject=`sticker` (`pack` is the format word). Known gap: 3-char CJK shape words (信息图 / 缩略图) don't match a clean trailing bigram — deferred.
+
+Bonus: this also **hardens the 人体图解 preserved-win** (subject now `人体`, not `图解`). Not fixed here: **black friday banner** (`banner` → Marvel's "Bruce Banner") — that one is a *protected-phrase* case (`banner` is not part of the "black friday" anchor, so subject-presence already excludes it); the residual is that Marvel's whole-token TITLE hit on `banner` is uncapped because a protected phrase disables the isolated-hit cap. That needs a **separate** lever (apply the isolated-hit cap under protected phrases) — filed as follow-up, not in this commit.
+
+Tests: `lib/__tests__/searchSubject.test.ts` (16) — the 4 Cluster-A cases, the 6 preserved wins, the 2 Fix-B single-concept cases, all-format fallback, and lexicon calibration (format words present; theme words absent). `tsc` clean; existing 37 scorer units unaffected (they assert `scoreRecord`/`selectFinalCandidates` given a `subjectPresent`, upstream of this change).
 
 ### Known residual (follow-up, not blocking)
 - Calibration used the eval-07-21 case set only, per the standing prohibition on query-by-query overfitting against the full 326-query benchmark. Re-run the benchmark before promoting to prod.
 
 ## Verification
-- `npx vitest run --config vitest.unit.config.ts lib/__tests__/relevanceScorer.test.ts` — 37/37 (5 new v1.1 cases: per-path base discount, 笔袋 food demotion-below-relevant-and-negative, rich-query drop, thin-query leniency, original-never-gated).
-- `npx tsc --noEmit` — clean.
-- Live re-eval against search-eval-07-21 queries + the full benchmark pending before prod promotion.
+- `npx vitest run --config vitest.unit.config.ts lib/__tests__/relevanceScorer.test.ts lib/__tests__/searchSubject.test.ts` — 53/53 (37 scorer v1.1 + 16 Fix-A `subjectUnits`: 4 Cluster-A cases, 6 preserved wins, 2 Fix-B single-concept, all-format fallback, lexicon calibration).
+- `npx tsc --noEmit` — clean (0 errors).
+- Live re-eval against search-eval-07-21 queries + the full 326-query benchmark pending before prod promotion (Fix B **and** Fix A now both landed; re-gate covers both).

--- a/docs/search-relevance-v2r3-r1-2026-07-21.md
+++ b/docs/search-relevance-v2r3-r1-2026-07-21.md
@@ -1,0 +1,53 @@
+# Search V2-R3 — Revision R1 (per-path weighting + result-count-aware filtering)
+
+_2026-07-21. Branch `baobao/search-relevance-prod-main-v2-r3-root-cause-fix-2026-07-19`. Scorer config `v1.1.0-2026-07-21`. Driven by the reviewer's search-eval-07-21 feedback (case screenshots in `raw/search-eval-07-21/`, v0 = prod, "new" = V2-R3). Companion to `docs/search-quality.md` (runbook) and `docs/search-and-content.md` thread-a._
+
+## Why R1
+
+V2-R3 replaced V0's **binary `hasStrict` gate + simple token score** with a single **uniform** deterministic scorer (`scoreRecord`), applying one weight set to every candidate regardless of which retrieval path surfaced it (original / rewrite / decomposition / relaxed). The eval-07-21 review confirmed the direction is right (six queries improved) but surfaced two structural problems the uniform schema causes:
+
+1. **Off-subject candidates from non-original paths leak in and rank high on thin queries.** Removing the binary gate — which dropped *all* relaxed-only records once any strict hit existed — also removed the one thing it did right: dropping records that only matched a *rewrite/decomposition* of the query, not the query itself. The uniform scorer gives a rewrite-path token-overlap the same `base_retrieval` credit as a match on the user's actual query.
+2. **No result-count awareness.** The floor (`MIN_SCORE_WHEN_ORIGINAL_NONEMPTY`) gates on original-empty-vs-nonempty, not on *how many* relevant results exist. Reviewer's principle: **result-rich queries should score+filter to push the relevant up and drop the clearly-irrelevant; result-poor queries should be left alone (filtering must not shrink an already-thin set).**
+
+## Case analysis (search-eval-07-21)
+
+### Improvements V2-R3 already delivered — R1 must preserve
+| Query | Verdict | Mechanism to keep |
+|---|---|---|
+| 电影海报 (movie poster) | clearly better | subject/coverage gate |
+| sticker pack | better — tennis/volleyball demoted | missing-subject + coverage |
+| product photo | better — 植物/cat/dog demoted | missing-subject |
+| 日历 (calendar) | top-5 better (top-10 ~same) | scoring |
+| logo | slightly better | scoring |
+| 人体图解 (anatomy) | new ≥ v0 | scoring |
+
+### Regressions / non-improvements R1 targets
+| Query | Problem | R1 fix |
+|---|---|---|
+| **笔袋 (pencil case)** | **regressed** — two western-food "doodle" posters + two Google-Gemini case-study infographics injected ABOVE the one relevant stationery card; v0's relevant stationery grid (en-zh "Pencil Case 笔袋", moyu, panda sets, boogi kits) displaced | per-path base discount + non-original off-subject extra demotion → food/Gemini score negative and drop; relevant stationery leads |
+| **促销海报 (promo poster)** | not significantly better — 4th result still irrelevant; top-3 swapped relevant-for-relevant | result-rich subject gate drops the off-subject tail |
+| 拼读卡 (phonics card) | no significant top-10 difference | neutral — no R1 change needed; noted, not forced |
+
+## R1 mechanisms (scorer `v1.1`)
+
+All additive to `scoreRecord` / `selectFinalCandidates`; **an extension of the strict/relaxed distinction, not a return to the binary gate.** Weights centralised in `lib/relevanceScorerConfig.ts`.
+
+1. **Per-path base trust** (`NON_ORIGINAL_BASE_FACTOR = 0.5`). `base_retrieval` (the carried-over primaryHits+bigramHits token-overlap, cap 20) is trusted in full only for original-query candidates; a non-original candidate measured that overlap against a *rewritten* slot, so it counts at ½. Only this low-weight term is path-scaled — the high-signal `exact_phrase` / `whole_token` / subject terms are path-independent, so a genuinely on-subject rewrite result is barely affected.
+
+2. **Non-original off-subject extra demotion** (`NON_ORIGINAL_OFFSUBJECT_EXTRA_PENALTY = -10`, added to `missing_subject_penalty`). The graded successor to `hasStrict`: an off-subject record surfaced **only** by a rewrite/decomposition/relaxed path (the exact 笔袋 food/Gemini profile) is demoted below the inclusion floor. Gated by `!subjectPresent`, so on-subject relaxed results — R3's whole point — are never touched. Net for the food poster: `base 10 + tags 8 − 15 − 10 = −7` < floor → dropped.
+
+3. **Result-count-aware subject gate** (`RESULT_RICH_MIN_ONSUBJECT = 8`, in `selectFinalCandidates`). A query is *result-rich* once ≥8 candidates are genuinely on-subject (subjectPresent AND positive score). For a rich query, a **non-original** candidate must carry the query subject to be included at all → prunes 促销海报's off-subject 4th and any 笔袋 food that survived mechanism 2. For a *thin* query the gate never engages — scoring+filtering cannot shrink an already-thin result (reviewer's "对返回结果少的 query 评分+过滤不影响结果"). Original-query candidates are never gated (Direction-1 floor invariant intact).
+
+### Invariants preserved
+- Original-pass records always kept when original is non-empty (Direction 1).
+- Never-zero guarantee when original is empty (top-N fallback ignores both floor and gate).
+- No new LLM calls / embeddings / learned reranker — every signal deterministic from catalog+query text.
+
+### Known residual (follow-up, not blocking)
+- `subjectPresent` for single-token CJK queries is the weak `titleHit || tagsHit` heuristic; a candidate with a *spurious* subject-token hit still reads as on-subject and escapes both mechanisms 2 and 3 (it is only demoted by mechanism 1). A stronger single-token subject test (e.g. requiring the hit in title, not just tags) is the next lever if 笔袋-class residue remains.
+- Calibration used the eval-07-21 case set only, per the standing prohibition on query-by-query overfitting against the full 326-query benchmark. Re-run the benchmark before promoting to prod.
+
+## Verification
+- `npx vitest run --config vitest.unit.config.ts lib/__tests__/relevanceScorer.test.ts` — 37/37 (5 new v1.1 cases: per-path base discount, 笔袋 food demotion-below-relevant-and-negative, rich-query drop, thin-query leniency, original-never-gated).
+- `npx tsc --noEmit` — clean.
+- Live re-eval against search-eval-07-21 queries + the full benchmark pending before prod promotion.

--- a/lib/__tests__/relevanceScorer.test.ts
+++ b/lib/__tests__/relevanceScorer.test.ts
@@ -1,0 +1,220 @@
+/**
+ * Unit tests for the Stage 7/9 unified relevance scorer
+ * (lib/relevanceScorer.ts) and Direction 6 phrase protection
+ * (lib/searchPhraseProtection.ts).
+ *
+ * These lock in the specific behaviors confirmed during implementation
+ * against the live V0/V2 servers this session (2026-07-19) -- see
+ * docs/daily_report/7.19/search-relevance-prod-main-v2/07_V0_TARGET_CASE_RECONFIRMATION.csv
+ * for the original evidence and 12_SCORER_CALIBRATION_RESULTS.csv for
+ * the full calibration-set pass/fail table.
+ */
+import { describe, it, expect } from "vitest";
+import {
+  scoreRecord,
+  applyFamilySaturation,
+  selectFinalCandidates,
+  type FieldHitInfo,
+  type ScoredCandidate,
+} from "../relevanceScorer";
+import { findProtectedPhrases, getAnchorTokens } from "../searchPhraseProtection";
+
+function fields(overrides: Partial<FieldHitInfo> = {}): FieldHitInfo {
+  return {
+    titleHit: false,
+    tagsHit: false,
+    paramsOnlyHit: false,
+    exactPhraseHit: false,
+    substringOnly: false,
+    subjectPresent: false,
+    ...overrides,
+  };
+}
+
+describe("searchPhraseProtection", () => {
+  it("finds 'coffee cup' as a protected phrase", () => {
+    expect(findProtectedPhrases("coffee cup")).toEqual(["coffee cup"]);
+  });
+
+  it("finds 'black friday' inside a longer query", () => {
+    expect(findProtectedPhrases("black friday banner")).toEqual(["black friday"]);
+  });
+
+  it("does not false-positive on unrelated queries", () => {
+    expect(findProtectedPhrases("plush pillow")).toEqual([]);
+    expect(findProtectedPhrases("periodic table")).toEqual([]);
+  });
+
+  it("anchor token for 'coffee cup' is 'coffee', not 'cup'", () => {
+    expect(getAnchorTokens(["coffee cup"])).toEqual(["coffee"]);
+  });
+
+  it("anchor token for 'black friday' is 'friday', not 'black'", () => {
+    expect(getAnchorTokens(["black friday"])).toEqual(["friday"]);
+  });
+});
+
+describe("relevanceScorer.scoreRecord", () => {
+  it("a World-Cup-style collision (tagsHit only, subject missing) scores below a genuine coffee match", () => {
+    // Reproduces the confirmed live-V0 case: "coffee cup" AND-matching a
+    // World Cup poster via scattered token hits with no real subject
+    // connection, vs. a genuine "coffee drinks" vocabulary card that
+    // carries the anchor token "coffee" but not the literal phrase.
+    const worldCupCollision = scoreRecord(
+      fields({ tagsHit: true, subjectPresent: false }),
+      { pathHits: 1, templateId: "template-world-cup-team-sticker-poster" },
+      2,
+    );
+    const genuineCoffeeMatch = scoreRecord(
+      fields({ titleHit: true, tagsHit: true, subjectPresent: true }),
+      { pathHits: 1, templateId: "template-vocabulary" },
+      2,
+    );
+    expect(genuineCoffeeMatch.final_score).toBeGreaterThan(worldCupCollision.final_score);
+    expect(worldCupCollision.missing_subject_penalty).toBeLessThan(0);
+    expect(worldCupCollision.reasons).toContain("core_subject_not_present_in_title_or_tags");
+  });
+
+  it("cross-path agreement is NOT credited when the subject is missing", () => {
+    // Reproduces the confirmed live-V0 case: a Marvel "Black Widow" MBTI
+    // card matched by 5 rewrite/decomposition paths (mostly via a
+    // generic "hero-banner" tag) for the query "black friday banner" --
+    // path count alone must not manufacture a competitive score for an
+    // off-subject record (Direction 5: "不简单按路径数量累加出不合理高分").
+    const manyPathsNoSubject = scoreRecord(
+      fields({ tagsHit: true, subjectPresent: false }),
+      { pathHits: 5, templateId: "template-mbti-generic" },
+      1,
+    );
+    expect(manyPathsNoSubject.path_agreement).toBe(0);
+    expect(manyPathsNoSubject.reasons.some((r) => r.includes("no_bonus"))).toBe(true);
+    expect(manyPathsNoSubject.final_score).toBeLessThan(0);
+  });
+
+  it("cross-path agreement IS credited when the subject is present", () => {
+    const manyPathsWithSubject = scoreRecord(
+      fields({ titleHit: true, subjectPresent: true }),
+      { pathHits: 4, templateId: "template-vocabulary-coffee" },
+      2,
+    );
+    expect(manyPathsWithSubject.path_agreement).toBeGreaterThan(0);
+  });
+
+  it("exact phrase match outweighs a substring-only collision", () => {
+    const exact = scoreRecord(
+      fields({ titleHit: true, exactPhraseHit: true, subjectPresent: true }),
+      { pathHits: 1, templateId: "t1" },
+      3,
+    );
+    const substringOnly = scoreRecord(
+      fields({ substringOnly: true, subjectPresent: false }),
+      { pathHits: 1, templateId: "t2" },
+      3,
+    );
+    expect(exact.final_score).toBeGreaterThan(substringOnly.final_score);
+    expect(substringOnly.substring_penalty).toBeLessThan(0);
+  });
+});
+
+describe("relevanceScorer.applyFamilySaturation", () => {
+  function candidate(id: string, templateId: string, score: number): ScoredCandidate {
+    return {
+      id,
+      templateId,
+      isOriginal: false,
+      breakdown: {
+        base_retrieval: score,
+        exact_phrase: 0,
+        whole_token: 0,
+        path_agreement: 0,
+        substring_penalty: 0,
+        missing_subject_penalty: 0,
+        family_saturation_penalty: 0,
+        final_score: score,
+        reasons: [],
+      },
+    };
+  }
+
+  it("penalizes records beyond the saturation threshold within the same template family", () => {
+    // 10 records from the SAME template, all with identical scores --
+    // after the 6th (family_saturation_threshold), each additional one
+    // should be pushed down by a growing penalty.
+    const many = Array.from({ length: 10 }, (_, i) => candidate(`id-${i}`, "template-x", 50));
+    const adjusted = applyFamilySaturation(many);
+    const penalized = adjusted.filter((c) => c.breakdown.family_saturation_penalty < 0);
+    expect(penalized.length).toBeGreaterThan(0);
+    // Later-ranked same-family records should never score HIGHER than
+    // earlier ones after adjustment (monotonic non-increasing).
+    for (let i = 1; i < adjusted.length; i++) {
+      expect(adjusted[i].breakdown.final_score).toBeLessThanOrEqual(
+        adjusted[i - 1].breakdown.final_score
+      );
+    }
+  });
+
+  it("does not penalize a diverse pool (different template families)", () => {
+    const diverse = Array.from({ length: 10 }, (_, i) => candidate(`id-${i}`, `template-${i}`, 50));
+    const adjusted = applyFamilySaturation(diverse);
+    expect(adjusted.every((c) => c.breakdown.family_saturation_penalty === 0)).toBe(true);
+  });
+
+  it("never excludes a record entirely (soft penalty, not a hard filter)", () => {
+    const many = Array.from({ length: 20 }, (_, i) => candidate(`id-${i}`, "template-x", 50));
+    const adjusted = applyFamilySaturation(many);
+    expect(adjusted.length).toBe(20);
+  });
+});
+
+describe("relevanceScorer.selectFinalCandidates (Direction 1 floor invariant)", () => {
+  function candidate(id: string, score: number): ScoredCandidate {
+    return {
+      id,
+      templateId: "t",
+      isOriginal: false,
+      breakdown: {
+        base_retrieval: 0, exact_phrase: 0, whole_token: 0, path_agreement: 0,
+        substring_penalty: 0, missing_subject_penalty: 0, family_saturation_penalty: 0,
+        final_score: score, reasons: [],
+      },
+    };
+  }
+
+  it("never drops an original-pass record, even with a very low score", () => {
+    const originalIds = new Set(["orig-1"]);
+    const scored = [candidate("orig-1", -100), candidate("noise-1", -50)];
+    const result = selectFinalCandidates(scored, originalIds);
+    expect(result.some((c) => c.id === "orig-1")).toBe(true);
+  });
+
+  it("drops low-scoring non-original noise when originals exist", () => {
+    const originalIds = new Set(["orig-1"]);
+    const scored = [candidate("orig-1", 10), candidate("noise-1", -100)];
+    const result = selectFinalCandidates(scored, originalIds);
+    expect(result.some((c) => c.id === "noise-1")).toBe(false);
+  });
+
+  it("keeps a good non-original candidate when originals exist", () => {
+    const originalIds = new Set(["orig-1"]);
+    const scored = [candidate("orig-1", 10), candidate("good-1", 20)];
+    const result = selectFinalCandidates(scored, originalIds);
+    expect(result.some((c) => c.id === "good-1")).toBe(true);
+  });
+
+  it("never returns zero results when originalIds is empty and candidates exist (never-zero guarantee)", () => {
+    const scored = Array.from({ length: 10 }, (_, i) => candidate(`id-${i}`, -100 + i));
+    const result = selectFinalCandidates(scored, new Set());
+    expect(result.length).toBeGreaterThan(0);
+  });
+
+  it("applies a real quality floor when originalIds is empty but enough candidates clear it", () => {
+    const scored = [
+      candidate("good-1", 20), candidate("good-2", 15), candidate("good-3", 10),
+      candidate("good-4", 8), candidate("good-5", 6),
+      candidate("bad-1", -100), candidate("bad-2", -100),
+    ];
+    const result = selectFinalCandidates(scored, new Set());
+    expect(result.some((c) => c.id === "bad-1")).toBe(false);
+    expect(result.some((c) => c.id === "bad-2")).toBe(false);
+  });
+});

--- a/lib/__tests__/relevanceScorer.test.ts
+++ b/lib/__tests__/relevanceScorer.test.ts
@@ -15,9 +15,14 @@ import {
   applyFamilySaturation,
   selectFinalCandidates,
   type FieldHitInfo,
+  type ScoreContext,
   type ScoredCandidate,
 } from "../relevanceScorer";
 import { findProtectedPhrases, getAnchorTokens } from "../searchPhraseProtection";
+import {
+  REQUIRED_TERM_COVERAGE_MIN_RATIO,
+  ISOLATED_HIT_SCORE_CAP,
+} from "../relevanceScorerConfig";
 
 function fields(overrides: Partial<FieldHitInfo> = {}): FieldHitInfo {
   return {
@@ -27,6 +32,22 @@ function fields(overrides: Partial<FieldHitInfo> = {}): FieldHitInfo {
     exactPhraseHit: false,
     substringOnly: false,
     subjectPresent: false,
+    coverageRatio: 1,
+    ...overrides,
+  };
+}
+
+// Default context for pre-existing (single-term / not-multi-term) test
+// cases below -- explicitly opts OUT of the V2-R3 mechanism B coverage
+// gate so these existing, already-confirmed behaviors are unaffected by
+// it (isMultiTermQuery: false is also the correct value for every
+// existing test here, since none of them represent a multi-term query).
+function ctx(overrides: Partial<ScoreContext> = {}): ScoreContext {
+  return {
+    pathHits: 1,
+    templateId: "t",
+    isMultiTermQuery: false,
+    hasProtectedPhraseQuery: false,
     ...overrides,
   };
 }
@@ -62,12 +83,12 @@ describe("relevanceScorer.scoreRecord", () => {
     // carries the anchor token "coffee" but not the literal phrase.
     const worldCupCollision = scoreRecord(
       fields({ tagsHit: true, subjectPresent: false }),
-      { pathHits: 1, templateId: "template-world-cup-team-sticker-poster" },
+      ctx({ templateId: "template-world-cup-team-sticker-poster" }),
       2,
     );
     const genuineCoffeeMatch = scoreRecord(
       fields({ titleHit: true, tagsHit: true, subjectPresent: true }),
-      { pathHits: 1, templateId: "template-vocabulary" },
+      ctx({ templateId: "template-vocabulary" }),
       2,
     );
     expect(genuineCoffeeMatch.final_score).toBeGreaterThan(worldCupCollision.final_score);
@@ -83,7 +104,7 @@ describe("relevanceScorer.scoreRecord", () => {
     // off-subject record (Direction 5: "不简单按路径数量累加出不合理高分").
     const manyPathsNoSubject = scoreRecord(
       fields({ tagsHit: true, subjectPresent: false }),
-      { pathHits: 5, templateId: "template-mbti-generic" },
+      ctx({ pathHits: 5, templateId: "template-mbti-generic" }),
       1,
     );
     expect(manyPathsNoSubject.path_agreement).toBe(0);
@@ -94,7 +115,7 @@ describe("relevanceScorer.scoreRecord", () => {
   it("cross-path agreement IS credited when the subject is present", () => {
     const manyPathsWithSubject = scoreRecord(
       fields({ titleHit: true, subjectPresent: true }),
-      { pathHits: 4, templateId: "template-vocabulary-coffee" },
+      ctx({ pathHits: 4, templateId: "template-vocabulary-coffee" }),
       2,
     );
     expect(manyPathsWithSubject.path_agreement).toBeGreaterThan(0);
@@ -103,16 +124,240 @@ describe("relevanceScorer.scoreRecord", () => {
   it("exact phrase match outweighs a substring-only collision", () => {
     const exact = scoreRecord(
       fields({ titleHit: true, exactPhraseHit: true, subjectPresent: true }),
-      { pathHits: 1, templateId: "t1" },
+      ctx({ templateId: "t1" }),
       3,
     );
     const substringOnly = scoreRecord(
       fields({ substringOnly: true, subjectPresent: false }),
-      { pathHits: 1, templateId: "t2" },
+      ctx({ templateId: "t2" }),
       3,
     );
     expect(exact.final_score).toBeGreaterThan(substringOnly.final_score);
     expect(substringOnly.substring_penalty).toBeLessThan(0);
+  });
+});
+
+// V2-R3 mechanism A: page.tsx's template-promoted-sibling branch now
+// calls the SAME deriveFieldHits helper the non-template branch uses,
+// once against the sibling's OWN blob (tier 1) and once against the
+// template's blob as a tier-2 fallback ONLY when the sibling has zero
+// own descriptive content. These tests exercise scoreRecord with the
+// two FieldHitInfo shapes that mechanism produces (a page.tsx-level
+// wiring test, not a scoreRecord unit test in isolation) -- the live
+// targeted evaluation (calibration queries "figure"/"doll"/"动漫周边"/
+// "cultural relic figure") is what confirms page.tsx actually produces
+// these shapes for real catalog data; see 08_V2_R3_TARGETED_GATE_RESULT.md.
+describe("relevanceScorer.scoreRecord (V2-R3 mechanism A: template-sibling evidence)", () => {
+  it("a sibling whose OWN title/tags match the query scores higher than a sibling that only inherited the template match", () => {
+    // Same template, same base_retrieval (both template-promoted,
+    // score:100 -> capped 20) -- the ONLY difference is per-sibling
+    // evidence, exactly mechanism A's intended effect.
+    const onTopicSibling = scoreRecord(
+      fields({ titleHit: true, tagsHit: true, subjectPresent: true, coverageRatio: 1 }),
+      ctx({ templateId: "template-mbti-marvel" }),
+      100,
+    );
+    const unrelatedSibling = scoreRecord(
+      fields({ titleHit: false, tagsHit: false, subjectPresent: false, coverageRatio: 0 }),
+      ctx({ templateId: "template-mbti-marvel" }),
+      100,
+    );
+    expect(onTopicSibling.final_score).toBeGreaterThan(unrelatedSibling.final_score);
+  });
+
+  it("an unrelated sibling does not inherit the on-topic sibling's high score (no flat tagsHit:true for every sibling)", () => {
+    const unrelatedSibling = scoreRecord(
+      fields({ titleHit: false, tagsHit: false, subjectPresent: false, coverageRatio: 0 }),
+      ctx({ templateId: "template-mbti-marvel" }),
+      100,
+    );
+    // Old behavior (tagsHit hardcoded true for every sibling) would have
+    // scored this at least base_retrieval(20) + whole_token_tags(8) = 28.
+    // Own-blob evidence being genuinely absent must score well below that.
+    expect(unrelatedSibling.final_score).toBeLessThan(28);
+  });
+
+  it("a sibling with no own content at all still gets a safe (non-catastrophic) template-level fallback score, not a hardcoded uniform high score", () => {
+    // Tier 2: sibling has zero own tags/topics/title, template's OWN
+    // title/category blob happens to match -- fallback still credits
+    // titleHit from the template level (today's pre-existing behavior
+    // for the template-level check), same as a real record would get.
+    const fallbackWithTemplateTitleMatch = scoreRecord(
+      fields({ titleHit: true, tagsHit: true, subjectPresent: true, coverageRatio: 1 }),
+      ctx({ templateId: "template-x" }),
+      100,
+    );
+    const fallbackWithoutTemplateTitleMatch = scoreRecord(
+      fields({ titleHit: false, tagsHit: true, subjectPresent: false, coverageRatio: 0 }),
+      ctx({ templateId: "template-x" }),
+      100,
+    );
+    // Fallback is still a FLOOR (base_retrieval alone keeps it
+    // non-catastrophic), never fully zeroed out just for lacking metadata.
+    expect(fallbackWithoutTemplateTitleMatch.final_score).toBeGreaterThanOrEqual(0);
+    // But the fallback must NOT restore a uniform high score for every
+    // sibling -- a fallback candidate whose template title also doesn't
+    // match must still score below one whose template title DOES match.
+    expect(fallbackWithTemplateTitleMatch.final_score).toBeGreaterThan(
+      fallbackWithoutTemplateTitleMatch.final_score
+    );
+  });
+
+  it("original candidates are still preserved by existence, not by an inflated score (Direction 1 unaffected by mechanism A)", () => {
+    // isOriginal is not read by scoreRecord at all -- confirmed by
+    // signature; a low-scoring original and a low-scoring non-original
+    // score identically here. Existence preservation is
+    // selectFinalCandidates' job (tested separately below, unchanged).
+    const originalCandidate: ScoredCandidate = {
+      id: "orig-1",
+      templateId: "template-x",
+      isOriginal: true,
+      breakdown: scoreRecord(fields({}), ctx({ templateId: "template-x" }), 1),
+    };
+    const nonOriginalCandidate: ScoredCandidate = {
+      id: "other-1",
+      templateId: "template-x",
+      isOriginal: false,
+      breakdown: scoreRecord(fields({}), ctx({ templateId: "template-x" }), 1),
+    };
+    expect(originalCandidate.breakdown.final_score).toBe(nonOriginalCandidate.breakdown.final_score);
+  });
+});
+
+// V2-R3 mechanism B: required multi-term coverage + isolated-hit score
+// cap (05_V2_R3_MINIMAL_FIX_DESIGN.md section 5). coverageRatio here
+// abstracts over EN (fraction of primary tokens matched) and CJK
+// (fraction of bigrams matched for an unsegmented compound) --
+// page.tsx's computeCoverageRatio is what actually produces this number
+// from real tokens; these tests exercise the SCORER's consumption of it.
+describe("relevanceScorer.scoreRecord (V2-R3 mechanism B: coverage + isolated-hit cap)", () => {
+  it("an isolated single-term hit in a multi-term query is capped (banner -> Bruce Banner shape: 1 of 3 terms matched)", () => {
+    const isolatedHit = scoreRecord(
+      fields({ titleHit: true, tagsHit: true, subjectPresent: true, coverageRatio: 1 / 3 }),
+      ctx({ isMultiTermQuery: true, templateId: "template-mbti-marvel" }),
+      1,
+    );
+    expect(isolatedHit.whole_token).toBe(ISOLATED_HIT_SCORE_CAP);
+    expect(isolatedHit.reasons).toContain("isolated_single_term_hit_capped");
+  });
+
+  it("majority term coverage in a multi-term query is NOT capped", () => {
+    const wellCovered = scoreRecord(
+      fields({ titleHit: true, tagsHit: true, subjectPresent: true, coverageRatio: 1 }),
+      ctx({ isMultiTermQuery: true, templateId: "template-vocabulary-coffee" }),
+      1,
+    );
+    expect(wellCovered.whole_token).toBeGreaterThan(ISOLATED_HIT_SCORE_CAP);
+    expect(wellCovered.reasons).not.toContain("isolated_single_term_hit_capped");
+  });
+
+  it("an exact phrase hit is never capped even with low coverage (composes with, does not fight, phrase-based matches)", () => {
+    const exactPhraseLowCoverage = scoreRecord(
+      fields({
+        titleHit: true,
+        tagsHit: true,
+        exactPhraseHit: true,
+        subjectPresent: true,
+        coverageRatio: 1 / 3,
+      }),
+      ctx({ isMultiTermQuery: true, templateId: "template-x" }),
+      1,
+    );
+    expect(exactPhraseLowCoverage.reasons).not.toContain("isolated_single_term_hit_capped");
+  });
+
+  it("subject + modifier coverage outscores an isolated wrong-sense hit on the same nominal evidence", () => {
+    const subjectPlusModifier = scoreRecord(
+      fields({ titleHit: true, tagsHit: true, subjectPresent: true, coverageRatio: 1 }),
+      ctx({ isMultiTermQuery: true, templateId: "template-x" }),
+      1,
+    );
+    const isolatedWrongSense = scoreRecord(
+      fields({ titleHit: true, tagsHit: true, subjectPresent: true, coverageRatio: 1 / 3 }),
+      ctx({ isMultiTermQuery: true, templateId: "template-x" }),
+      1,
+    );
+    expect(subjectPlusModifier.final_score).toBeGreaterThan(isolatedWrongSense.final_score);
+  });
+
+  it("sense-collision shape (subject token present but coverage below the required ratio) loses the subject-presence credit", () => {
+    // "sale banner" shape: only the longest token ("banner") matched; the
+    // OTHER token ("sale") is completely absent -- coverage 1/2 = 0.5
+    // hits the boundary; use 1/3 (a 3-term query, e.g. "black friday
+    // banner" with only "banner" hit and no protected-phrase anchor) to
+    // unambiguously demonstrate the below-threshold case.
+    const belowThreshold = scoreRecord(
+      fields({ titleHit: true, tagsHit: true, subjectPresent: true, coverageRatio: 1 / 3 }),
+      ctx({ isMultiTermQuery: true, templateId: "template-mbti-marvel" }),
+      1,
+    );
+    expect(belowThreshold.missing_subject_penalty).toBeLessThan(0);
+    expect(
+      belowThreshold.reasons.some((r) => r.startsWith("subject_token_present_but_coverage_"))
+    ).toBe(true);
+  });
+
+  it("single-word queries are completely unaffected by the coverage gate (isMultiTermQuery: false bypasses it even at low coverageRatio)", () => {
+    const singleTermQuery = scoreRecord(
+      fields({ titleHit: true, tagsHit: true, subjectPresent: true, coverageRatio: 0.1 }),
+      ctx({ isMultiTermQuery: false, templateId: "template-x" }),
+      1,
+    );
+    expect(singleTermQuery.missing_subject_penalty).toBe(0);
+    expect(singleTermQuery.whole_token).toBeGreaterThan(ISOLATED_HIT_SCORE_CAP);
+  });
+
+  it("a protected-phrase query is exempt from the coverage gate and isolated-hit cap (composes with, does not replace, the phrase dictionary)", () => {
+    // "coffee cup" shape: anchor token ("coffee") present, satisfying
+    // subjectPresent via the existing phrase mechanism, but the OTHER
+    // word of the phrase not literally present -> low nominal coverage.
+    // The coverage gate must not re-penalize what phrase protection
+    // already deliberately allows.
+    const protectedPhraseLowCoverage = scoreRecord(
+      fields({ titleHit: true, subjectPresent: true, coverageRatio: 1 / 2 }),
+      ctx({ isMultiTermQuery: true, hasProtectedPhraseQuery: true, templateId: "template-vocabulary-coffee" }),
+      1,
+    );
+    expect(protectedPhraseLowCoverage.missing_subject_penalty).toBe(0);
+    expect(
+      protectedPhraseLowCoverage.reasons.some((r) => r.startsWith("subject_token_present_but_coverage_"))
+    ).toBe(false);
+  });
+
+  it("required coverage threshold is exported and matches the isolated-hit cap boundary (documents the intentional shared 0.5 default)", () => {
+    expect(REQUIRED_TERM_COVERAGE_MIN_RATIO).toBe(0.5);
+  });
+
+  it("a well-covered CJK compound (bigram-coverage shape: 2 of 3 bigrams matched, e.g. 新品横幅) is not capped", () => {
+    const cjkWellCovered = scoreRecord(
+      fields({ titleHit: true, tagsHit: true, subjectPresent: true, coverageRatio: 2 / 3 }),
+      ctx({ isMultiTermQuery: true, templateId: "template-banner-cjk" }),
+      1,
+    );
+    expect(cjkWellCovered.whole_token).toBeGreaterThan(ISOLATED_HIT_SCORE_CAP);
+  });
+
+  it("a poorly-covered CJK compound (bigram-coverage shape: 1 of 3 bigrams matched) is capped, same principle as the EN case", () => {
+    const cjkPoorlyCovered = scoreRecord(
+      fields({ titleHit: true, tagsHit: true, subjectPresent: true, coverageRatio: 1 / 3 }),
+      ctx({ isMultiTermQuery: true, templateId: "template-banner-cjk" }),
+      1,
+    );
+    expect(cjkPoorlyCovered.whole_token).toBe(ISOLATED_HIT_SCORE_CAP);
+  });
+
+  it("whole-token-hit-outweighs-substring-only rule is preserved under mechanism B (multi-term context)", () => {
+    const wholeToken = scoreRecord(
+      fields({ titleHit: true, subjectPresent: true, coverageRatio: 1 }),
+      ctx({ isMultiTermQuery: true, templateId: "t1" }),
+      3,
+    );
+    const substringOnly = scoreRecord(
+      fields({ substringOnly: true, subjectPresent: false, coverageRatio: 0 }),
+      ctx({ isMultiTermQuery: true, templateId: "t2" }),
+      3,
+    );
+    expect(wholeToken.final_score).toBeGreaterThan(substringOnly.final_score);
   });
 });
 

--- a/lib/__tests__/relevanceScorer.test.ts
+++ b/lib/__tests__/relevanceScorer.test.ts
@@ -22,6 +22,8 @@ import { findProtectedPhrases, getAnchorTokens } from "../searchPhraseProtection
 import {
   REQUIRED_TERM_COVERAGE_MIN_RATIO,
   ISOLATED_HIT_SCORE_CAP,
+  NON_ORIGINAL_BASE_FACTOR,
+  RESULT_RICH_MIN_ONSUBJECT,
 } from "../relevanceScorerConfig";
 
 function fields(overrides: Partial<FieldHitInfo> = {}): FieldHitInfo {
@@ -48,7 +50,39 @@ function ctx(overrides: Partial<ScoreContext> = {}): ScoreContext {
     templateId: "t",
     isMultiTermQuery: false,
     hasProtectedPhraseQuery: false,
+    // Default isOriginal: true so every pre-existing numeric expectation below
+    // (which was calibrated before the v1.1 per-path base discount) is
+    // unchanged -- full base trust is the original-query behavior. New v1.1
+    // tests set isOriginal: false explicitly.
+    isOriginal: true,
     ...overrides,
+  };
+}
+
+// Convenience: a scored candidate for selectFinalCandidates tests.
+function cand(
+  id: string,
+  final_score: number,
+  subjectPresent: boolean,
+  isOriginal = false,
+  templateId = "t",
+): ScoredCandidate {
+  return {
+    id,
+    templateId,
+    isOriginal,
+    breakdown: {
+      base_retrieval: 0,
+      exact_phrase: 0,
+      whole_token: 0,
+      path_agreement: 0,
+      substring_penalty: 0,
+      missing_subject_penalty: 0,
+      family_saturation_penalty: 0,
+      final_score,
+      subjectPresent,
+      reasons: [],
+    },
   };
 }
 
@@ -376,6 +410,7 @@ describe("relevanceScorer.applyFamilySaturation", () => {
         missing_subject_penalty: 0,
         family_saturation_penalty: 0,
         final_score: score,
+        subjectPresent: false,
         reasons: [],
       },
     };
@@ -420,7 +455,7 @@ describe("relevanceScorer.selectFinalCandidates (Direction 1 floor invariant)", 
       breakdown: {
         base_retrieval: 0, exact_phrase: 0, whole_token: 0, path_agreement: 0,
         substring_penalty: 0, missing_subject_penalty: 0, family_saturation_penalty: 0,
-        final_score: score, reasons: [],
+        final_score: score, subjectPresent: false, reasons: [],
       },
     };
   }
@@ -461,5 +496,63 @@ describe("relevanceScorer.selectFinalCandidates (Direction 1 floor invariant)", 
     const result = selectFinalCandidates(scored, new Set());
     expect(result.some((c) => c.id === "bad-1")).toBe(false);
     expect(result.some((c) => c.id === "bad-2")).toBe(false);
+  });
+});
+
+describe("relevanceScorer v1.1 -- per-path weighting + result-rich subject gate", () => {
+  it("trusts a non-original candidate's base_retrieval less than an identical original one", () => {
+    const f = fields({ titleHit: true, subjectPresent: true });
+    const original = scoreRecord(f, ctx({ isOriginal: true }), 20);
+    const rewrite = scoreRecord(f, ctx({ isOriginal: false }), 20);
+    // Only the low-weight base term is path-scaled; the on-subject signal
+    // (whole_token/subject) is preserved so an on-subject rewrite stays positive.
+    expect(rewrite.final_score).toBeLessThan(original.final_score);
+    expect(rewrite.base_retrieval).toBeCloseTo(original.base_retrieval * NON_ORIGINAL_BASE_FACTOR);
+    expect(rewrite.final_score).toBeGreaterThan(0);
+  });
+
+  it("ranks a relevant on-subject card above an off-subject rewrite hit (笔袋 food regression)", () => {
+    // Regression: a non-original off-subject poster (spurious tag hit, high raw
+    // token-overlap) outranked the relevant stationery card. It must now rank
+    // strictly below, and score negative (so a floor/gate can drop it).
+    const relevantStationery = scoreRecord(
+      fields({ titleHit: true, tagsHit: true, subjectPresent: true }),
+      ctx({ isOriginal: false }),
+      10,
+    );
+    const offSubjectFoodPoster = scoreRecord(
+      fields({ tagsHit: true, subjectPresent: false }),
+      ctx({ isOriginal: false }),
+      20,
+    );
+    expect(offSubjectFoodPoster.final_score).toBeLessThan(relevantStationery.final_score);
+    expect(offSubjectFoodPoster.final_score).toBeLessThan(0);
+  });
+
+  it("drops off-subject non-original candidates on a RESULT-RICH query", () => {
+    const onSubject = Array.from({ length: RESULT_RICH_MIN_ONSUBJECT }, (_, i) =>
+      cand(`on-${i}`, 30, true, false));
+    const offSubjectNonOriginal = cand("food", 5, false, false);
+    const originalIds = new Set(["on-0"]); // original-nonempty branch
+    const kept = selectFinalCandidates([...onSubject, offSubjectNonOriginal], originalIds);
+    expect(kept.some((c) => c.id === "food")).toBe(false);
+    expect(kept.filter((c) => c.breakdown.subjectPresent).length).toBe(RESULT_RICH_MIN_ONSUBJECT);
+  });
+
+  it("keeps off-subject non-original candidates on a THIN query (few-results leniency)", () => {
+    const onSubject = Array.from({ length: 3 }, (_, i) => cand(`on-${i}`, 30, true, false));
+    const offSubjectNonOriginal = cand("food", 5, false, false);
+    const originalIds = new Set(["on-0"]);
+    const kept = selectFinalCandidates([...onSubject, offSubjectNonOriginal], originalIds);
+    expect(kept.some((c) => c.id === "food")).toBe(true);
+  });
+
+  it("never gates an ORIGINAL candidate out, even off-subject on a rich query", () => {
+    const onSubject = Array.from({ length: RESULT_RICH_MIN_ONSUBJECT }, (_, i) =>
+      cand(`on-${i}`, 30, true, false));
+    const offSubjectOriginal = cand("orig-offsubject", 5, false, true);
+    const originalIds = new Set(["orig-offsubject", "on-0"]);
+    const kept = selectFinalCandidates([...onSubject, offSubjectOriginal], originalIds);
+    expect(kept.some((c) => c.id === "orig-offsubject")).toBe(true);
   });
 });

--- a/lib/__tests__/searchSubject.test.ts
+++ b/lib/__tests__/searchSubject.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect } from "vitest";
+import { subjectUnits, FORMAT_TOKENS } from "../searchSubject";
+
+// subjectUnits() returns the query's SUBJECT unit(s) — the theme/head-noun content
+// with format/output words removed. A record is "subject-present" iff its title+tags
+// blob contains at least one of these units. These tests assert the returned units,
+// which is where the Cluster-A fix lives (page.tsx's deriveFieldHits only applies
+// tokenInBlob to them).
+
+describe("subjectUnits — Cluster A (format-word-aware subject)", () => {
+  // Confirmed-live regression cases: the OLD "longest token = subject" picked the
+  // format word; the fix must return the THEME instead.
+  it("wine label → wine (not label)", () => {
+    expect(subjectUnits(["wine", "label"], [], "wine label")).toEqual(["wine"]);
+  });
+
+  it("字母海报 → 字母 content bigram (not the 海报 format bigram, not the whole compound)", () => {
+    // CJK compound tokenizes to one primary token + bigrams.
+    const units = subjectUnits(["字母海报"], ["字母", "母海", "海报"], "字母海报");
+    expect(units).toContain("字母");
+    expect(units).not.toContain("海报");
+  });
+
+  it("巧克力礼盒 → 巧克力 theme (not the 礼盒 gift-box format word)", () => {
+    const units = subjectUnits(["巧克力礼盒"], ["巧克", "克力", "力礼", "礼盒"], "巧克力礼盒");
+    expect(units).toContain("巧克");
+    expect(units).not.toContain("礼盒");
+  });
+
+  it("人体图解 → 人体 theme (not the 图解 diagram format word)", () => {
+    const units = subjectUnits(["人体图解"], ["人体", "体图", "图解"], "人体图解");
+    expect(units).toContain("人体");
+    expect(units).not.toContain("图解");
+  });
+});
+
+describe("subjectUnits — preserved wins (must NOT change)", () => {
+  it("product photo → product (photo is format; product photo win intact)", () => {
+    expect(subjectUnits(["product", "photo"], [], "product photo")).toEqual(["product"]);
+  });
+
+  it("movie poster → movie (poster is format)", () => {
+    expect(subjectUnits(["movie", "poster"], [], "movie poster")).toEqual(["movie"]);
+  });
+
+  it("sticker pack → sticker (pack is format, sticker is the THEME — kept out of the lexicon)", () => {
+    expect(subjectUnits(["sticker", "pack"], [], "sticker pack")).toEqual(["sticker"]);
+  });
+
+  it("logo → logo (single ASCII word; logo is a theme, not a format word)", () => {
+    expect(subjectUnits(["logo"], [], "logo")).toEqual(["logo"]);
+  });
+
+  it("促销海报 → 促销 theme (promo poster; theme survives, 海报 dropped)", () => {
+    const units = subjectUnits(["促销海报"], ["促销", "销海", "海报"], "促销海报");
+    expect(units).toContain("促销");
+    expect(units).not.toContain("海报");
+  });
+
+  it("日历 → 日历 (single-concept CJK; whole token, Fix B strictness)", () => {
+    expect(subjectUnits(["日历"], ["日历"], "日历")).toEqual(["日历"]);
+  });
+});
+
+describe("subjectUnits — Fix B strictness preserved (single-concept CJK)", () => {
+  it("笔袋 → 笔袋 whole token (not split; not a format word)", () => {
+    expect(subjectUnits(["笔袋"], ["笔袋"], "笔袋")).toEqual(["笔袋"]);
+  });
+
+  it("元素周期表 → whole compound (no format word → single concept, NOT bigram-loosened)", () => {
+    // Critical: a multi-char non-format CJK compound must stay strict (require the
+    // full term), so a record carrying only 元素 (element) is NOT subject-present.
+    expect(subjectUnits(["元素周期表"], ["元素", "素周", "周期", "期表"], "元素周期表"))
+      .toEqual(["元素周期表"]);
+  });
+});
+
+describe("subjectUnits — all-format fallback", () => {
+  it("bare 'poster' → poster (query is entirely format; it becomes its own subject)", () => {
+    expect(subjectUnits(["poster"], [], "poster")).toEqual(["poster"]);
+  });
+
+  it("'poster banner' (all format) → both tokens (nothing left to prefer)", () => {
+    expect(subjectUnits(["poster", "banner"], [], "poster banner")).toEqual(["poster", "banner"]);
+  });
+});
+
+describe("FORMAT_TOKENS lexicon calibration", () => {
+  it("contains the confirmed format/output words (EN + CJK)", () => {
+    for (const w of ["poster", "label", "banner", "package", "box", "photo",
+                     "海报", "礼盒", "图解", "包装", "标签", "横幅"]) {
+      expect(FORMAT_TOKENS.has(w)).toBe(true);
+    }
+  });
+
+  it("EXCLUDES theme words that merely co-occur with a format", () => {
+    for (const w of ["sticker", "logo", "wine", "product", "movie", "巧克", "字母", "人体", "促销"]) {
+      expect(FORMAT_TOKENS.has(w)).toBe(false);
+    }
+  });
+});

--- a/lib/relevanceScorer.ts
+++ b/lib/relevanceScorer.ts
@@ -28,6 +28,9 @@ import {
   REQUIRED_TERM_COVERAGE_MIN_RATIO,
   ISOLATED_HIT_MAX_COVERAGE_RATIO,
   ISOLATED_HIT_SCORE_CAP,
+  NON_ORIGINAL_BASE_FACTOR,
+  NON_ORIGINAL_OFFSUBJECT_EXTRA_PENALTY,
+  RESULT_RICH_MIN_ONSUBJECT,
 } from "./relevanceScorerConfig";
 
 export type FieldHitInfo = {
@@ -82,6 +85,13 @@ export type ScoreContext = {
    *  gate / isolated-hit cap below are skipped entirely for these
    *  queries so the two mechanisms compose without conflict. */
   hasProtectedPhraseQuery: boolean;
+  /** v1.1 per-path weighting: true when this candidate came from the
+   *  ORIGINAL (non-rewrite) query pass. Non-original candidates matched a
+   *  REWRITTEN/decomposed query slot, so their carried-over base_retrieval
+   *  token-overlap is weaker evidence and is trusted at NON_ORIGINAL_BASE_FACTOR
+   *  (config). The high-signal exact_phrase/whole_token/subject terms are
+   *  path-independent — an on-subject rewrite result is barely affected. */
+  isOriginal: boolean;
 };
 
 export type ScoreBreakdown = {
@@ -93,6 +103,11 @@ export type ScoreBreakdown = {
   missing_subject_penalty: number;
   family_saturation_penalty: number;
   final_score: number;
+  /** v1.1: the EFFECTIVE subject-presence decision (raw subjectPresent
+   *  combined with the multi-term coverage gate). Exposed so the pool-level
+   *  selectFinalCandidates can apply the result-rich subject gate without
+   *  re-deriving it. */
+  subjectPresent: boolean;
   reasons: string[];
 };
 
@@ -111,7 +126,16 @@ export function scoreRecord(
   const reasons: string[] = [];
   const w = SCORER_WEIGHTS;
 
-  const base_retrieval = Math.min(baseRetrievalScore, 20) * w.base_retrieval;
+  // v1.1 per-path weighting: trust the carried-over token-overlap base signal
+  // in full only for original-query candidates; a non-original candidate's
+  // overlap was measured against a rewritten/decomposed slot, so it is weaker
+  // evidence (NON_ORIGINAL_BASE_FACTOR). Only this low-weight base term is
+  // path-scaled — the high-signal terms below are path-independent.
+  const pathBaseFactor = ctx.isOriginal ? 1 : NON_ORIGINAL_BASE_FACTOR;
+  const base_retrieval = Math.min(baseRetrievalScore, 20) * w.base_retrieval * pathBaseFactor;
+  if (!ctx.isOriginal && base_retrieval > 0) {
+    reasons.push(`non_original_base_trust_${NON_ORIGINAL_BASE_FACTOR}`);
+  }
 
   let exact_phrase = 0;
   if (fields.exactPhraseHit) {
@@ -181,6 +205,15 @@ export function scoreRecord(
   if (!subjectPresent) {
     missing_subject_penalty = w.missing_subject_penalty;
     reasons.push("core_subject_not_present_in_title_or_tags");
+    // v1.1 per-path extension of V0's binary hasStrict gate: an off-subject
+    // candidate surfaced ONLY by a non-original (rewrite/decomposition/relaxed)
+    // path -- the exact profile V0's gate dropped wholesale (笔袋 food / Gemini
+    // posters) -- gets an extra demotion so it falls below the inclusion floor.
+    // On-subject relaxed results are untouched (subjectPresent short-circuits).
+    if (!ctx.isOriginal) {
+      missing_subject_penalty += NON_ORIGINAL_OFFSUBJECT_EXTRA_PENALTY;
+      reasons.push("non_original_off_subject_extra_demotion");
+    }
   }
 
   if (fields.paramsOnlyHit) {
@@ -226,6 +259,7 @@ export function scoreRecord(
     missing_subject_penalty,
     family_saturation_penalty: 0,
     final_score,
+    subjectPresent,
     reasons,
   };
 }
@@ -302,21 +336,41 @@ export function selectFinalCandidates(
   scored: ScoredCandidate[],
   originalIds: Set<string>
 ): ScoredCandidate[] {
+  // v1.1 result-count-aware inclusion. A query is "result-rich" once it has
+  // >= RESULT_RICH_MIN_ONSUBJECT genuinely on-subject candidates (subject
+  // present AND a positive final_score). For a RICH query, a NON-ORIGINAL
+  // (rewrite/decomposition/relaxed) candidate must itself carry the query
+  // subject to be included -- this prunes the off-subject tail (the promo-
+  // poster "第四个结果不相关" case, and the 笔袋 western-food / Gemini posters
+  // once enough real stationery candidates are present) on top of the existing
+  // score floor. For a THIN query the gate never engages, so scoring+filtering
+  // cannot shrink an already-thin result (reviewer directive: "对返回结果少的
+  // query 评分+过滤不影响结果"). Original-query candidates are NEVER gated here
+  // -- the Direction-1 floor invariant preserves them regardless.
+  const onSubjectCount = scored.filter(
+    (c) => c.breakdown.subjectPresent && c.breakdown.final_score > 0
+  ).length;
+  const isResultRich = onSubjectCount >= RESULT_RICH_MIN_ONSUBJECT;
+  const passesRichGate = (c: ScoredCandidate) =>
+    !isResultRich || originalIds.has(c.id) || c.breakdown.subjectPresent;
+
   if (originalIds.size === 0) {
     const aboveFloor = scored.filter(
-      (c) => c.breakdown.final_score >= MIN_SCORE_WHEN_ORIGINAL_EMPTY
+      (c) => c.breakdown.final_score >= MIN_SCORE_WHEN_ORIGINAL_EMPTY && passesRichGate(c)
     );
     if (aboveFloor.length >= Math.min(MIN_KEPT_WHEN_ORIGINAL_EMPTY, scored.length)) {
       return aboveFloor;
     }
-    // Not enough candidates clear the floor -- never-zero guarantee:
-    // take the top-scoring candidates regardless of the floor rather
-    // than returning an emptier (or empty) set.
+    // Not enough candidates clear the floor/gate -- never-zero guarantee:
+    // take the top-scoring candidates regardless of the floor AND the rich
+    // gate rather than returning an emptier (or empty) set.
     return [...scored]
       .sort((a, b) => b.breakdown.final_score - a.breakdown.final_score)
       .slice(0, MIN_KEPT_WHEN_ORIGINAL_EMPTY);
   }
   return scored.filter(
-    (c) => originalIds.has(c.id) || c.breakdown.final_score >= MIN_SCORE_WHEN_ORIGINAL_NONEMPTY
+    (c) =>
+      originalIds.has(c.id) ||
+      (c.breakdown.final_score >= MIN_SCORE_WHEN_ORIGINAL_NONEMPTY && passesRichGate(c))
   );
 }

--- a/lib/relevanceScorer.ts
+++ b/lib/relevanceScorer.ts
@@ -22,7 +22,13 @@
 // not sufficient justification per the task's explicit instruction not
 // to "mechanically implement every candidate feature."
 
-import { SCORER_WEIGHTS, MIN_SCORE_WHEN_ORIGINAL_NONEMPTY } from "./relevanceScorerConfig";
+import {
+  SCORER_WEIGHTS,
+  MIN_SCORE_WHEN_ORIGINAL_NONEMPTY,
+  REQUIRED_TERM_COVERAGE_MIN_RATIO,
+  ISOLATED_HIT_MAX_COVERAGE_RATIO,
+  ISOLATED_HIT_SCORE_CAP,
+} from "./relevanceScorerConfig";
 
 export type FieldHitInfo = {
   /** Whole-token (ASCII) or substring (CJK) hit in the record's
@@ -41,9 +47,20 @@ export type FieldHitInfo = {
   /** The record's ONLY match evidence is a CJK bigram/substring fallback
    *  hit with no ASCII whole-token or phrase hit anywhere. */
   substringOnly: boolean;
-  /** Whether every primary query token that constitutes the CORE
-   *  SUBJECT (see subjectTokens) is present somewhere in title or tags. */
+  /** Whether the query's designated subject/anchor token (protected-
+   *  phrase anchor, or the longest primary token / longest bigram for a
+   *  single-term query) is present somewhere in title or tags. RAW
+   *  signal -- for a multi-term query this is combined with
+   *  `coverageRatio` by scoreRecord (see ISOLATED_HIT / coverage-gate
+   *  logic below) before it is treated as "subject genuinely present". */
   subjectPresent: boolean;
+  /** V2-R3 mechanism B: fraction (0..1) of the query's required terms
+   *  found as whole-token hits (or, for an unsegmented CJK compound,
+   *  matched bigrams) anywhere in this record's title/tags blob. Always
+   *  1 for single-term queries (nothing to cover) -- see
+   *  relevanceScorerConfig.ts REQUIRED_TERM_COVERAGE_MIN_RATIO /
+   *  ISOLATED_HIT_MAX_COVERAGE_RATIO for how this is used. */
+  coverageRatio: number;
 };
 
 export type ScoreContext = {
@@ -51,6 +68,20 @@ export type ScoreContext = {
    *  passes) that independently matched this record. */
   pathHits: number;
   templateId: string;
+  /** V2-R3 mechanism B: true when the ORIGINAL query decomposes into 2+
+   *  required terms (2+ primary tokens, or 2+ bigrams for an
+   *  unsegmented CJK compound) -- gates the coverage/isolated-hit logic
+   *  below. False for genuine single-term queries, which this mechanism
+   *  deliberately does not touch. Query-level, not candidate-level, so
+   *  it lives on the context rather than FieldHitInfo. */
+  isMultiTermQuery: boolean;
+  /** V2-R3 mechanism B: true when the ORIGINAL query contains a
+   *  lib/searchPhraseProtection.ts protected phrase. That mechanism
+   *  already has its own, narrower anchor-token subject-presence
+   *  semantics (a deliberate partial-coverage allowance); the coverage
+   *  gate / isolated-hit cap below are skipped entirely for these
+   *  queries so the two mechanisms compose without conflict. */
+  hasProtectedPhraseQuery: boolean;
 };
 
 export type ScoreBreakdown = {
@@ -98,6 +129,26 @@ export function scoreRecord(
     reasons.push("whole_token_hit_in_tags");
   }
 
+  // V2-R3 mechanism B (required multi-term coverage): for a multi-term
+  // query not governed by a protected phrase, the raw subjectPresent
+  // signal (which the caller derives from just the ONE designated
+  // subject/anchor token) is only treated as genuine subject presence
+  // when coverageRatio also clears a majority threshold -- otherwise a
+  // wrong-sense hit on a single token of a multi-word query (e.g.
+  // "banner" -> Marvel "Bruce Banner") no longer gets a free pass just
+  // because that one token happened to be the longest. Protected-phrase
+  // queries keep their existing, narrower anchor-token allowance
+  // untouched (see ScoreContext.hasProtectedPhraseQuery doc).
+  const coverageGateApplies = ctx.isMultiTermQuery && !ctx.hasProtectedPhraseQuery;
+  const subjectPresent = coverageGateApplies
+    ? fields.subjectPresent && fields.coverageRatio >= REQUIRED_TERM_COVERAGE_MIN_RATIO
+    : fields.subjectPresent;
+  if (coverageGateApplies && fields.subjectPresent && !subjectPresent) {
+    reasons.push(
+      `subject_token_present_but_coverage_${fields.coverageRatio.toFixed(2)}_below_required_${REQUIRED_TERM_COVERAGE_MIN_RATIO}`
+    );
+  }
+
   // Cross-path agreement is only credited when the record actually
   // carries the query's core subject. Multiple broad/generic rewrite or
   // decomposition paths (e.g. a single-word "banner" output slot)
@@ -110,7 +161,7 @@ export function scoreRecord(
   // hit) outscored genuinely Black-Friday-relevant content purely on
   // path count, even though missing_subject_penalty correctly fired.
   let path_agreement = 0;
-  if (ctx.pathHits > 1 && fields.subjectPresent) {
+  if (ctx.pathHits > 1 && subjectPresent) {
     path_agreement = Math.min(
       (ctx.pathHits - 1) * w.path_agreement_per_hit,
       w.path_agreement_cap
@@ -127,13 +178,32 @@ export function scoreRecord(
   }
 
   let missing_subject_penalty = 0;
-  if (!fields.subjectPresent) {
+  if (!subjectPresent) {
     missing_subject_penalty = w.missing_subject_penalty;
     reasons.push("core_subject_not_present_in_title_or_tags");
   }
 
   if (fields.paramsOnlyHit) {
     reasons.push("match_relies_on_low_signal_params_field_only");
+  }
+
+  // V2-R3 mechanism B (isolated-hit cap): a multi-term-query candidate
+  // whose only real evidence is a single matched term/bigram (coverage
+  // at or below the isolated threshold) and no exact-phrase
+  // corroboration should not stack both the title and tags whole-token
+  // weights -- that combination is reserved for genuine multi-signal
+  // agreement. Composes with (does not replace) the phrase-protection
+  // dictionary: any query with a protected phrase is exempted above via
+  // coverageGateApplies, and any candidate with an actual exact-phrase
+  // hit is exempted via the !fields.exactPhraseHit check below.
+  if (
+    coverageGateApplies &&
+    !fields.exactPhraseHit &&
+    fields.coverageRatio <= ISOLATED_HIT_MAX_COVERAGE_RATIO &&
+    whole_token > ISOLATED_HIT_SCORE_CAP
+  ) {
+    whole_token = ISOLATED_HIT_SCORE_CAP;
+    reasons.push("isolated_single_term_hit_capped");
   }
 
   const final_score =

--- a/lib/relevanceScorer.ts
+++ b/lib/relevanceScorer.ts
@@ -1,0 +1,252 @@
+// Stage 7/9: unified, lightweight, text-based, deterministic relevance
+// scorer. Replaces the ad hoc "score = primaryHits + bigramHits" +
+// multiplicative multi-hit-boost + binary hasStrict gate with a single
+// explainable weighted score per candidate, used to unify Directions
+// 3 (strict/relaxed gate), 4 (phrase/token/substring priority), and 5
+// (rewrite path quality) as required by the post-meeting design doc
+// section 9-10.
+//
+// Explicitly NOT implemented (per design doc boundaries + task
+// prohibitions): no new LLM calls, no external embeddings, no learned
+// reranker, no reliance on human ground truth. Every signal here is a
+// deterministic function of text already present in the catalog/query.
+//
+// Every signal below has direct V0 evidence from
+// docs/daily_report/7.19/search-relevance-prod-main-v2/07_V0_TARGET_CASE_RECONFIRMATION.csv
+// and 09_SCORE_FEATURE_AUDIT.csv -- see those files for the case-by-case
+// justification of each weight's existence. Signals proposed in the
+// design doc's candidate list WITHOUT direct V0 evidence (e.g. a
+// separate Category/Topic Consistency term beyond what field_support
+// already captures, and a standalone "Modifier Coverage" term) are
+// deliberately NOT implemented here -- seeing them in the design doc is
+// not sufficient justification per the task's explicit instruction not
+// to "mechanically implement every candidate feature."
+
+import { SCORER_WEIGHTS, MIN_SCORE_WHEN_ORIGINAL_NONEMPTY } from "./relevanceScorerConfig";
+
+export type FieldHitInfo = {
+  /** Whole-token (ASCII) or substring (CJK) hit in the record's
+   *  title/category blob -- the highest-signal field. */
+  titleHit: boolean;
+  /** Hit in the tags/topics/search_aliases blob -- medium signal. */
+  tagsHit: boolean;
+  /** True when the ONLY hit came from the params/description blob
+   *  (lowest signal -- mirrors the existing compound-noun demotion
+   *  guard's intuition that a param-only hit is weaker evidence). */
+  paramsOnlyHit: boolean;
+  /** A protected phrase (lib/searchPhraseProtection.ts) or the complete
+   *  multi-token query was found verbatim (not just all-tokens-present-
+   *  somewhere) in the title/tags blob. */
+  exactPhraseHit: boolean;
+  /** The record's ONLY match evidence is a CJK bigram/substring fallback
+   *  hit with no ASCII whole-token or phrase hit anywhere. */
+  substringOnly: boolean;
+  /** Whether every primary query token that constitutes the CORE
+   *  SUBJECT (see subjectTokens) is present somewhere in title or tags. */
+  subjectPresent: boolean;
+};
+
+export type ScoreContext = {
+  /** Number of distinct retrieval paths (original + rewrite/decomp
+   *  passes) that independently matched this record. */
+  pathHits: number;
+  templateId: string;
+};
+
+export type ScoreBreakdown = {
+  base_retrieval: number;
+  exact_phrase: number;
+  whole_token: number;
+  path_agreement: number;
+  substring_penalty: number;
+  missing_subject_penalty: number;
+  family_saturation_penalty: number;
+  final_score: number;
+  reasons: string[];
+};
+
+/**
+ * Score one candidate record. `baseRetrievalScore` is the pre-existing
+ * primaryHits+bigramHits (or 100 for template-promoted strict matches)
+ * value computed by page.tsx's scoreBlob -- carried forward rather than
+ * discarded so ties within the same signal tier still respect the
+ * original token-overlap ordering.
+ */
+export function scoreRecord(
+  fields: FieldHitInfo,
+  ctx: ScoreContext,
+  baseRetrievalScore: number
+): ScoreBreakdown {
+  const reasons: string[] = [];
+  const w = SCORER_WEIGHTS;
+
+  const base_retrieval = Math.min(baseRetrievalScore, 20) * w.base_retrieval;
+
+  let exact_phrase = 0;
+  if (fields.exactPhraseHit) {
+    exact_phrase = w.exact_phrase;
+    reasons.push("exact_phrase_match_in_title_or_tags");
+  }
+
+  let whole_token = 0;
+  if (fields.titleHit && !fields.substringOnly) {
+    whole_token += w.whole_token_title;
+    reasons.push("whole_token_hit_in_title");
+  }
+  if (fields.tagsHit && !fields.substringOnly) {
+    whole_token += w.whole_token_tags;
+    reasons.push("whole_token_hit_in_tags");
+  }
+
+  // Cross-path agreement is only credited when the record actually
+  // carries the query's core subject. Multiple broad/generic rewrite or
+  // decomposition paths (e.g. a single-word "banner" output slot)
+  // converging on the SAME popular-tag record is not genuine relevance
+  // agreement -- it's exactly the "path count manufactures an
+  // unreasonably high score" failure mode Direction 5 explicitly
+  // prohibits ("不简单按路径数量累加出不合理高分"). Confirmed live during
+  // implementation testing: without this guard, a Marvel "Black Widow"
+  // MBTI card matched by 5 paths (mostly via a generic "hero-banner" tag
+  // hit) outscored genuinely Black-Friday-relevant content purely on
+  // path count, even though missing_subject_penalty correctly fired.
+  let path_agreement = 0;
+  if (ctx.pathHits > 1 && fields.subjectPresent) {
+    path_agreement = Math.min(
+      (ctx.pathHits - 1) * w.path_agreement_per_hit,
+      w.path_agreement_cap
+    );
+    reasons.push(`matched_by_${ctx.pathHits}_paths`);
+  } else if (ctx.pathHits > 1) {
+    reasons.push(`matched_by_${ctx.pathHits}_paths_but_subject_missing_no_bonus`);
+  }
+
+  let substring_penalty = 0;
+  if (fields.substringOnly) {
+    substring_penalty = w.substring_penalty;
+    reasons.push("substring_or_bigram_only_no_whole_token_hit");
+  }
+
+  let missing_subject_penalty = 0;
+  if (!fields.subjectPresent) {
+    missing_subject_penalty = w.missing_subject_penalty;
+    reasons.push("core_subject_not_present_in_title_or_tags");
+  }
+
+  if (fields.paramsOnlyHit) {
+    reasons.push("match_relies_on_low_signal_params_field_only");
+  }
+
+  const final_score =
+    base_retrieval +
+    exact_phrase +
+    whole_token +
+    path_agreement +
+    substring_penalty +
+    missing_subject_penalty;
+  // family_saturation_penalty filled in by applyFamilySaturation after
+  // the full candidate set is known (it's a pool-level, not per-record,
+  // signal).
+
+  return {
+    base_retrieval,
+    exact_phrase,
+    whole_token,
+    path_agreement,
+    substring_penalty,
+    missing_subject_penalty,
+    family_saturation_penalty: 0,
+    final_score,
+    reasons,
+  };
+}
+
+export type ScoredCandidate = {
+  id: string;
+  templateId: string;
+  breakdown: ScoreBreakdown;
+  isOriginal: boolean;
+};
+
+/**
+ * Direction 5 / design doc 9.2 Template Family Saturation: after the
+ * full candidate pool is scored, records are grouped by templateId in
+ * CURRENT score order; once a family has already placed
+ * `family_saturation_threshold` records ahead of a given record, each
+ * additional record from that family gets a growing penalty (capped),
+ * pushing later same-family duplicates down without ever excluding the
+ * family entirely (soft penalty, not a hard filter -- consistent with
+ * "不通过hard filter制造新的零结果").
+ *
+ * Mutates each candidate's breakdown.family_saturation_penalty and
+ * final_score in place, then returns the input array re-sorted by the
+ * updated final_score (desc).
+ */
+export function applyFamilySaturation(candidates: ScoredCandidate[]): ScoredCandidate[] {
+  const w = SCORER_WEIGHTS;
+  const byScoreDesc = [...candidates].sort(
+    (a, b) => b.breakdown.final_score - a.breakdown.final_score
+  );
+  const familyCount = new Map<string, number>();
+  for (const c of byScoreDesc) {
+    const seen = familyCount.get(c.templateId) ?? 0;
+    familyCount.set(c.templateId, seen + 1);
+    if (seen >= w.family_saturation_threshold) {
+      const excess = seen - w.family_saturation_threshold + 1;
+      const penalty = Math.max(
+        excess * w.family_saturation_penalty_per_excess,
+        w.family_saturation_penalty_cap
+      );
+      c.breakdown.family_saturation_penalty = penalty;
+      c.breakdown.final_score += penalty;
+      c.breakdown.reasons.push(
+        `template_family_saturation_rank_${seen + 1}_in_family`
+      );
+    }
+  }
+  return byScoreDesc.sort((a, b) => b.breakdown.final_score - a.breakdown.final_score);
+}
+
+/**
+ * Direction 1 safety filter: given the fully-scored, family-saturation-
+ * adjusted candidate pool and the set of record ids that came from the
+ * ORIGINAL (non-rewrite) query pass, decide the final included set.
+ *
+ * Invariant (design doc section 8.1): when original_results is
+ * non-empty, every original-pass record must remain in the final pool
+ * (existence is a floor -- rank can still move via scoring). Non-
+ * original records below MIN_SCORE_WHEN_ORIGINAL_NONEMPTY are dropped
+ * ONLY when the original pass already produced at least one record,
+ * so this can never itself create a new zero-result case.
+ */
+// When the original query produced NO results at all, rewrite/
+// decomposition paths are the only source of candidates. A quality
+// floor still applies here (Direction 3: "Relaxed受最低质量和数量约束，
+// 不允许flooding" applies regardless of whether the original was empty)
+// -- but capped by a never-zero guarantee: the top N candidates by
+// score are always kept even if all of them are below the floor, so
+// this filter can never itself turn an already-thin result into zero.
+const MIN_KEPT_WHEN_ORIGINAL_EMPTY = 5;
+const MIN_SCORE_WHEN_ORIGINAL_EMPTY = -5;
+
+export function selectFinalCandidates(
+  scored: ScoredCandidate[],
+  originalIds: Set<string>
+): ScoredCandidate[] {
+  if (originalIds.size === 0) {
+    const aboveFloor = scored.filter(
+      (c) => c.breakdown.final_score >= MIN_SCORE_WHEN_ORIGINAL_EMPTY
+    );
+    if (aboveFloor.length >= Math.min(MIN_KEPT_WHEN_ORIGINAL_EMPTY, scored.length)) {
+      return aboveFloor;
+    }
+    // Not enough candidates clear the floor -- never-zero guarantee:
+    // take the top-scoring candidates regardless of the floor rather
+    // than returning an emptier (or empty) set.
+    return [...scored]
+      .sort((a, b) => b.breakdown.final_score - a.breakdown.final_score)
+      .slice(0, MIN_KEPT_WHEN_ORIGINAL_EMPTY);
+  }
+  return scored.filter(
+    (c) => originalIds.has(c.id) || c.breakdown.final_score >= MIN_SCORE_WHEN_ORIGINAL_NONEMPTY
+  );
+}

--- a/lib/relevanceScorerConfig.ts
+++ b/lib/relevanceScorerConfig.ts
@@ -11,7 +11,10 @@
 // for the frozen snapshot (weights + version + calibration-set hash +
 // freeze timestamp + adjustment rationale).
 
-export const SCORER_CONFIG_VERSION = "v1.1.0-2026-07-21";
+// v1.2.0 (2026-07-22): Fix A / Cluster A — format-word-aware query subject
+// (lib/searchSubject.ts). No SCORER_WEIGHTS change; subject derivation upstream
+// in deriveFieldHits now excludes FORMAT_TOKENS. See docs/search-relevance-v2r3-r1-2026-07-21.md.
+export const SCORER_CONFIG_VERSION = "v1.2.0-2026-07-22";
 
 export const SCORER_WEIGHTS = {
   // ---- Positive signals ----

--- a/lib/relevanceScorerConfig.ts
+++ b/lib/relevanceScorerConfig.ts
@@ -11,7 +11,7 @@
 // for the frozen snapshot (weights + version + calibration-set hash +
 // freeze timestamp + adjustment rationale).
 
-export const SCORER_CONFIG_VERSION = "v1.0.0-2026-07-19";
+export const SCORER_CONFIG_VERSION = "v1.1.0-2026-07-21";
 
 export const SCORER_WEIGHTS = {
   // ---- Positive signals ----
@@ -112,3 +112,58 @@ export const ISOLATED_HIT_MAX_COVERAGE_RATIO = 0.5;
 // should score like a medium-confidence tag match, not a strong title
 // match plus a tag match.
 export const ISOLATED_HIT_SCORE_CAP = 8;
+
+// ---------------------------------------------------------------------------
+// v1.1 (2026-07-21) — per-path weighting + result-count-aware inclusion.
+//
+// Motivation (search-eval-07-21 review, see
+// docs/search-relevance-v2r3-r1-2026-07-21.md and search-and-content.md
+// thread-a): removing V0's binary hasStrict gate let
+// NON-ORIGINAL (rewrite / decomposition / relaxed) off-subject candidates flow
+// through and score positive on THIN queries — the "笔袋" regression injected
+// two western-food posters + two Google-Gemini case-study infographics ABOVE
+// the one relevant stationery card, and displaced v0's relevant stationery
+// grid. The uniform single-weight schema treats a token match found via a
+// rewrite of the query the same as a match on the user's actual query. These
+// two knobs make the weighting PATH-DEPENDENT (an extension of the old strict/
+// relaxed distinction, not a return to the binary gate) and add a
+// result-count-aware inclusion rule, per the reviewer's directive:
+//   "对返回结果多的 query 用打分+过滤把最相关的排上来、很不相关的过滤掉;
+//    对返回结果少的 query 评分+过滤不影响结果."
+// ---------------------------------------------------------------------------
+
+// Per-path trust on the carried-over base_retrieval signal. base_retrieval is
+// the pre-existing primaryHits+bigramHits token-overlap count; for a NON-
+// ORIGINAL candidate that overlap was measured against a REWRITTEN/decomposed
+// query slot, not the user's own query, so it is weaker evidence and is
+// trusted at this fraction. Original-query candidates keep full base_retrieval
+// (factor 1.0, applied implicitly). Deliberately only discounts the low-weight
+// base signal (cap 20) — the high-signal exact_phrase/whole_token/subject terms
+// are path-independent, so a genuinely on-subject rewrite result is barely
+// affected while pure token-overlap noise from a rewrite loses its free floor.
+export const NON_ORIGINAL_BASE_FACTOR = 0.5;
+
+// Extra demotion added to missing_subject_penalty for an OFF-SUBJECT candidate
+// that came from a NON-ORIGINAL (rewrite/decomposition/relaxed) path. This is
+// the graded successor to V0's binary hasStrict gate: V0 dropped every
+// relaxed-only record once any strict hit existed, which R3 correctly removed
+// (it also dropped legitimate on-subject relaxed results). But the ONE profile
+// V0's gate was right to drop -- an off-subject record surfaced only by a
+// rewrite/decomposition of the query (the 笔袋 western-food + Google-Gemini
+// posters) -- must still be demoted below the inclusion floor. This penalty
+// applies ONLY when the subject is absent, so on-subject relaxed results (R3's
+// whole point) are never touched: subjectPresent short-circuits it in
+// relevanceScorer.scoreRecord. Sized so base(≤20·0.5=10)+tags(8)+
+// missing_subject(-15)+this(-10) = -7 < the inclusion floor.
+export const NON_ORIGINAL_OFFSUBJECT_EXTRA_PENALTY = -10;
+
+// A query is "result-rich" once at least this many candidates are genuinely
+// on-subject (subjectPresent AND a positive final_score). For a result-rich
+// query, selectFinalCandidates requires NON-ORIGINAL candidates to carry the
+// query subject to be included at all — pruning the off-subject tail (the
+// promo-poster "第四个结果不相关" case, and the 笔袋 food posters once enough
+// real stationery candidates are present). For a result-POOR (thin) query this
+// gate never engages, so scoring+filtering does not shrink an already-thin
+// result — the Direction-1 never-zero invariant and original-floor invariant
+// are untouched. Calibrated to the V2-R3 eval set only, not the full benchmark.
+export const RESULT_RICH_MIN_ONSUBJECT = 8;

--- a/lib/relevanceScorerConfig.ts
+++ b/lib/relevanceScorerConfig.ts
@@ -1,0 +1,70 @@
+// Stage 8: frozen scorer weight configuration. Single source of truth for
+// all weights used by lib/relevanceScorer.ts -- do not hardcode weights
+// anywhere else (design doc 9.2: "评分权重集中配置，单一配置源").
+//
+// Calibrated against docs/daily_report/7.19/search-relevance-prod-main-v2/11_SCORER_CALIBRATION_SET.csv
+// (fixed calibration set only -- NOT tuned against the full 326-query
+// benchmark, per the task's explicit prohibition on query-by-query
+// overfitting after seeing full results).
+//
+// See docs/daily_report/7.19/search-relevance-prod-main-v2/13_SCORER_CONFIG_LOCK.json
+// for the frozen snapshot (weights + version + calibration-set hash +
+// freeze timestamp + adjustment rationale).
+
+export const SCORER_CONFIG_VERSION = "v1.0.0-2026-07-19";
+
+export const SCORER_WEIGHTS = {
+  // ---- Positive signals ----
+  // Base retrieval score carried over from the existing strict/relaxed
+  // primaryHits+bigramHits count -- kept small relative to the new
+  // explainable signals below so it nudges rather than dominates.
+  base_retrieval: 1.0,
+  // Full protected phrase (lib/searchPhraseProtection.ts) or the
+  // complete multi-token query found verbatim (word-boundary-checked)
+  // in the record's high-signal blob (title/category).
+  exact_phrase: 40,
+  // Whole-token match ratio in the high-signal blob (title/category),
+  // scaled 0..1 by primaryHits/totalTokens.
+  whole_token_title: 18,
+  // Whole-token match ratio in the medium-signal blob (tags/topics/aliases).
+  whole_token_tags: 8,
+  // Bonus when 2+ distinct retrieval paths (original/rewrite/decomposition)
+  // independently surfaced the same record -- cross-path agreement is a
+  // genuine relevance signal, but capped so it can't alone promote an
+  // irrelevant record (see PATH_AGREEMENT_CAP below).
+  path_agreement_per_hit: 3,
+  path_agreement_cap: 12,
+
+  // ---- Negative signals ----
+  // Match relied only on a CJK substring/bigram fallback or an ASCII
+  // token found only inside a multi-word param value (the existing
+  // compound-noun demotion case), not a whole-token/phrase hit in a
+  // high-signal field.
+  substring_penalty: -22,
+  // Query has a recognized core subject (a protected phrase, or the
+  // longest primary token) that does NOT appear anywhere in the record's
+  // title or tags blob (i.e. only params/description carry a partial
+  // match). Distinct from substring_penalty: this fires even on a
+  // legitimate whole-token match if that token was a modifier, not the
+  // subject.
+  missing_subject_penalty: -15,
+  // Applied per-record once a template_id family has already contributed
+  // this many records to the CURRENT candidate pool before ranking --
+  // discourages one large template family from crowding out everything
+  // else. See relevanceScorer.applyFamilySaturation.
+  family_saturation_threshold: 6,
+  family_saturation_penalty_per_excess: -6,
+  family_saturation_penalty_cap: -30,
+} as const;
+
+// Minimum final_score for a record to be included in the ranked result
+// set AT ALL when the original (non-rewrite) query already produced at
+// least one candidate -- prevents pure noise from a low-quality rewrite
+// path diluting a query that already had legitimate original results.
+// Deliberately does NOT apply when original_results is empty (Direction
+// 1 invariant: never let a floor rule create a NEW zero-result case).
+export const MIN_SCORE_WHEN_ORIGINAL_NONEMPTY = -5;
+
+// Direction 5: per-path and total candidate pool caps.
+export const PATH_CANDIDATE_CAP = 40; // max candidates a single non-original path may contribute
+export const TOTAL_CANDIDATE_POOL_CAP = 80; // unchanged from V0's existing .slice(0, 80)

--- a/lib/relevanceScorerConfig.ts
+++ b/lib/relevanceScorerConfig.ts
@@ -68,3 +68,47 @@ export const MIN_SCORE_WHEN_ORIGINAL_NONEMPTY = -5;
 // Direction 5: per-path and total candidate pool caps.
 export const PATH_CANDIDATE_CAP = 40; // max candidates a single non-original path may contribute
 export const TOTAL_CANDIDATE_POOL_CAP = 80; // unchanged from V0's existing .slice(0, 80)
+
+// V2-R3 mechanism B (required multi-term coverage + isolated-hit cap --
+// see docs/daily_report/7.19/search-relevance-prod-main-v2/v2-r3-root-cause-fix/05_V2_R3_MINIMAL_FIX_DESIGN.md
+// section 5). Both apply ONLY to multi-term queries (2+ primary tokens,
+// e.g. English "black friday banner", or 2+ CJK bigrams for an
+// unsegmented compound like "新品横幅") and are gated OFF for queries
+// governed by a protected phrase (lib/searchPhraseProtection.ts already
+// has its own narrower anchor-token semantics for those, composed with
+// rather than overridden by this mechanism). Single-term queries are
+// completely unaffected (coverage of 1/1 is trivial) per the task's
+// explicit instruction not to mechanically penalize single-word queries.
+
+// Minimum fraction of a multi-term query's required terms (primary
+// tokens, or bigrams for an unsegmented CJK compound) that must be found
+// in a candidate's title/tags blob for the query's subject to be
+// considered present. A MAJORITY, not all terms: requiring 100% would
+// wrongly zero out legitimate results missing one modifier word (e.g. a
+// record literally titled "wine" for query "wine label" whose blob
+// happens not to literally contain "label"). Calibrated against the
+// V2-R3 14-query calibration set only (03_V2_R3_CASE_SPLIT.csv).
+export const REQUIRED_TERM_COVERAGE_MIN_RATIO = 0.5;
+
+// Maximum coverage ratio (see above) at or below which a candidate's
+// whole-token evidence is considered "isolated" -- i.e. its only real
+// signal is a single matched term (or bigram) with no exact-phrase
+// corroboration. This is the general, non-blacklist mechanism behind
+// the confirmed "banner" -> Marvel "Bruce Banner" MBTI-card and similar
+// wrong-sense-collision regressions: a candidate that matches only one
+// of a multi-term query's tokens should not score as if it matched the
+// whole query. Deliberately the SAME default value as
+// REQUIRED_TERM_COVERAGE_MIN_RATIO (see relevanceScorer.scoreRecord for
+// why sharing the boundary is intentional -- an exactly-half-covered
+// 2-term candidate can still legitimately clear the subject-presence bar
+// while its raw score is still capped for being single-signal evidence).
+export const ISOLATED_HIT_MAX_COVERAGE_RATIO = 0.5;
+
+// Cap on the COMBINED whole_token_title + whole_token_tags contribution
+// when the isolated-hit condition above is met -- prevents a single
+// isolated term hit from stacking both the title (18) and tags (8)
+// weights (26 total) the way genuine multi-signal agreement does. Set
+// equal to whole_token_tags (the medium-signal weight): an isolated hit
+// should score like a medium-confidence tag match, not a strong title
+// match plus a tag match.
+export const ISOLATED_HIT_SCORE_CAP = 8;

--- a/lib/searchPhraseProtection.ts
+++ b/lib/searchPhraseProtection.ts
@@ -1,0 +1,104 @@
+// Direction 6 (phrase protection half): a small, evidence-backed list of
+// query phrases that must be treated as a single atomic unit during
+// tokenization/matching instead of being split into independent tokens.
+//
+// WHY THIS EXISTS: page.tsx's tokenizer (buildSearchTokens) splits a
+// query into independent primary tokens with no concept of "these two
+// words only mean something together." For ASCII tokens, tokenInBlob
+// already requires whole-word boundaries (so "cup" alone won't match
+// inside "cupcake"), but an AND-match against a multi-word query still
+// succeeds when a record's blob happens to contain BOTH "coffee" and
+// "cup" as separate words in an unrelated context. Confirmed live on V0
+// this session (2026-07-19): "coffee cup" strict/relaxed-matches multiple
+// "World Cup" team-sticker-poster inspirations, and "black friday banner"
+// ranks a Marvel "Black Widow" MBTI character card as the #1 inspiration.
+// See docs/daily_report/7.19/search-relevance-prod-main-v2/07_V0_TARGET_CASE_RECONFIRMATION.csv
+// for the raw evidence (SUB_01, SUB_03 rows).
+//
+// SCOPE DISCIPLINE: only phrases with DIRECT, CONFIRMED V0 evidence from
+// the Stage 4 reconfirmation are included here. The design doc's Stage 6
+// candidate list also named 咖啡杯 / 元素周期表 / 黑色星期五 / 迷你手办 /
+// periodic table, but those were logged as NEEDS_MORE_EVIDENCE (thin
+// results or root cause not yet isolated, see 07_V0_TARGET_CASE_RECONFIRMATION.csv)
+// rather than a confirmed collision -- per the task's explicit instruction
+// not to build an "unlimited hand-built dictionary," they are NOT added
+// here. If Stage 10's broad-template trace produces direct evidence for
+// any of them, they can be added with the same evidence-and-comment
+// discipline used below. Do not add entries without a case + evidence
+// comment.
+
+export type ProtectedPhrase = {
+  /** Normalized (lowercased, tsToSc'd) phrase text. */
+  phrase: string;
+  /**
+   * The phrase's semantically load-bearing word for Subject Coverage
+   * purposes -- deliberately NOT necessarily the linguistic head noun,
+   * but whichever word of the phrase is evidenced as the LOW-collision,
+   * high-specificity anchor. A record is considered "on subject" for
+   * this protected phrase if it contains the phrase verbatim OR this
+   * anchor token as a whole-token hit -- this lets genuinely related but
+   * not verbatim-phrase-matching content (e.g. "coffee drinks", "coffee
+   * machine" for the query "coffee cup") still count as on-subject,
+   * while the OTHER word of the phrase (the collision-prone one, e.g.
+   * "cup" inside "World Cup", "black" inside "Black Widow") is
+   * deliberately NOT treated as sufficient on its own.
+   */
+  anchorToken: string;
+  /** Evidence case id(s) from 07_V0_TARGET_CASE_RECONFIRMATION.csv. */
+  evidenceCaseIds: string[];
+  /** One-line human-readable justification. */
+  reason: string;
+};
+
+export const PROTECTED_PHRASES: ProtectedPhrase[] = [
+  {
+    phrase: "coffee cup",
+    anchorToken: "coffee",
+    evidenceCaseIds: ["SUB_01"],
+    reason:
+      "'cup' alone AND-matches World Cup team-sticker-poster inspirations once combined with other tokens across multi-path rewrite expansion; confirmed live on V0 2026-07-19 (284/335 templates matched, World Cup posters in top results). 'coffee' is the anchor because it is the collision-free, semantically specific word; 'cup' is the collision-prone word and is deliberately NOT treated as sufficient subject evidence on its own.",
+  },
+  {
+    phrase: "black friday",
+    anchorToken: "friday",
+    evidenceCaseIds: ["SUB_03"],
+    reason:
+      "'black' alone matches a Marvel 'Black Widow' MBTI character card as the #1 inspiration result for 'black friday banner'; confirmed live on V0 2026-07-19. 'friday' is the anchor because it is not a Marvel-character-name collision risk; 'black' is deliberately NOT treated as sufficient subject evidence on its own.",
+  },
+];
+
+// Sorted longest-first so multi-word phrase matching in the tokenizer
+// checks longer candidates before shorter ones (avoids a shorter phrase
+// masking a longer one that contains it, not currently a real case here
+// but a correctness invariant worth keeping as the list grows).
+const SORTED_PHRASES = [...PROTECTED_PHRASES].sort(
+  (a, b) => b.phrase.length - a.phrase.length
+);
+
+/**
+ * Given an already-normalized (lowercased, tsToSc'd) query string, return
+ * the list of protected phrases it contains, longest match first. Used
+ * by the tokenizer to keep a protected phrase atomic (one token) instead
+ * of letting its constituent words be split and independently matched.
+ */
+const ANCHOR_BY_PHRASE = new Map(PROTECTED_PHRASES.map((p) => [p.phrase, p.anchorToken]));
+
+/**
+ * Anchor tokens (see ProtectedPhrase.anchorToken doc) for the given list
+ * of found protected phrases -- used for Subject Coverage so a record
+ * doesn't need the full verbatim phrase to count as "on subject", just
+ * the low-collision anchor word.
+ */
+export function getAnchorTokens(foundPhrases: string[]): string[] {
+  return foundPhrases
+    .map((p) => ANCHOR_BY_PHRASE.get(p))
+    .filter((t): t is string => !!t);
+}
+
+export function findProtectedPhrases(normalizedQuery: string): string[] {
+  const found: string[] = [];
+  for (const { phrase } of SORTED_PHRASES) {
+    if (normalizedQuery.includes(phrase)) found.push(phrase);
+  }
+  return found;
+}

--- a/lib/searchSubject.ts
+++ b/lib/searchSubject.ts
@@ -1,0 +1,66 @@
+// Cluster-A fix (2026-07-22): format-word-aware query subject detection.
+//
+// Problem (confirmed live on wine label / 字母海报 / 巧克力礼盒 / 人体图解): the
+// relevance scorer approximated a multi-term query's SUBJECT as its longest
+// token, which for "head-noun + format" queries is usually the FORMAT word
+// (label > wine, 海报, 礼盒, 图解). Wrong-sense content that carried the format
+// word ("label printer", MBTI "poster" groups, gift-box merch, architecture
+// "图解") then read as subject-present and out-ranked the correct head-noun
+// results (which lack the format word and got the missing-subject penalty).
+//
+// Fix: the subject is the query's THEME / head-noun content — the non-format
+// token(s). A candidate matching only a format/output word is NOT subject-present.
+//
+// FORMAT_TOKENS = the query-token surface of taxonomy.json's FORMAT axis. The
+// English entries are the format/output subset of lib/taxonomy.json
+// `content_shapes` (slugs: poster, card, flashcard, grid, packaging, map, quote,
+// timeline, collection, guide, infographic…) + `information_types` — i.e. this
+// leverages the same subject-vs-shape separation the taxonomy already draws,
+// rather than a parallel hand-rolled list. The CJK entries are a supplement:
+// taxonomy carries NO CJK shape surface forms, yet every confirmed CJK Cluster-A
+// regression hinges on one (海报/图解/礼盒/包装). Only 2-char CJK forms are useful
+// (they must match as a clean query bigram); 3-char shape words (信息图/缩略图) are
+// a known gap. Keep this tight — add unambiguous format/output/container words
+// only; theme words that merely often co-occur with a format (sticker, logo,
+// map地图, recipe, menu) must NOT go in.
+export const FORMAT_TOKENS: ReadonlySet<string> = new Set([
+  // English — aligned to taxonomy content_shapes / information_types
+  "poster", "banner", "flyer", "brochure", "leaflet", "label", "package", "packaging",
+  "box", "mockup", "card", "flashcard", "sheet", "pack", "template", "cover", "wallpaper",
+  "infographic", "diagram", "photo", "thumbnail", "layout",
+  // CJK 2-char surface forms — supplement (taxonomy has none)
+  "海报", "横幅", "传单", "手册", "标签", "包装", "礼盒", "样机", "卡片", "模板",
+  "封面", "壁纸", "图解", "图表", "图鉴", "名片", "单页", "排版", "缩略",
+]);
+
+/**
+ * The query SUBJECT unit(s) to test for presence in a record's blob — the theme /
+ * head-noun content, with format/output words removed.
+ *
+ * - Segmented (2+ primary tokens, e.g. "wine label"): the content primary tokens
+ *   ("wine"); a candidate carrying only "label" is off-subject.
+ * - Unsegmented CJK compound containing a format bigram (e.g. 字母海报 = 字母 +
+ *   海报, or 人体图解 = 人体 + 图解): the NON-format content bigrams (字母 / 人体).
+ * - Otherwise a single concept — an ASCII single word ("logo") OR a CJK compound
+ *   with no format word (笔袋, 元素周期表): the whole token. This preserves Fix B's
+ *   strictness (require the full compound, not a partial bigram) for single-concept
+ *   CJK queries.
+ * - A query made entirely of format words ("poster", "poster banner") falls back
+ *   to the tokens themselves so a bare-format query still has a subject.
+ */
+export function subjectUnits(
+  primaryTokens: string[],
+  bigrams: string[],
+  fullQueryPhrase: string,
+): string[] {
+  if (primaryTokens.length >= 2) {
+    const content = primaryTokens.filter((t) => !FORMAT_TOKENS.has(t));
+    return content.length > 0 ? content : primaryTokens;
+  }
+  const fmt = bigrams.filter((b) => FORMAT_TOKENS.has(b));
+  if (fmt.length > 0 && bigrams.length > fmt.length) {
+    return bigrams.filter((b) => !FORMAT_TOKENS.has(b));
+  }
+  const subj = primaryTokens[0] ?? bigrams[0] ?? fullQueryPhrase;
+  return subj ? [subj] : [];
+}


### PR DESCRIPTION
## Summary
- Implements V2-R3 search relevance root cause fixes
- Adds relevance scoring improvements for template fallback and multi-word coverage
- Adds single-point match limitation to reduce irrelevant retrieval

## Validation
- Unit tests passed
- Build passed
- Gate checks passed
- Targeted regression evaluation completed