### PR TITLE
fix(build): cast Object.entries value in client-messages (unblock Ver…

### DIFF
--- a/lib/client-messages.ts
+++ b/lib/client-messages.ts
@@ -51,8 +51,11 @@ export function pickClientMessages<T extends Record<string, unknown>>(messages: 
     }
     if (v && typeof v === "object" && !Array.isArray(v)) {
       // Container namespace (e.g. `blog`): reduce article children, keep the rest.
+      // Cast the entries value to Msg — TS doesn't flow the recursive Msg union
+      // through Object.entries here, so it widens to `unknown` without this.
       const inner: { [k: string]: Msg } = {};
-      for (const [ik, iv] of Object.entries(v)) inner[ik] = isArticle(iv) ? lighten(iv) : iv;
+      for (const [ik, iv] of Object.entries(v) as [string, Msg][])
+        inner[ik] = isArticle(iv) ? lighten(iv) : iv;
       out[k] = inner;
       continue;
     }


### PR DESCRIPTION
…cel build)

TS was not flowing the recursive Msg union through Object.entries, widening the value to unknown and failing next build type-check (Type unknown is not assignable to type Msg). Cast the entries to [string, Msg][]. Pre-existing error, surfaced now as a hard build failure.